### PR TITLE
LSM: configurable limits, background flush, table-service cleanup

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -5,6 +5,12 @@ logger:
   console: true
 compaction:
   interval: 60000
+flush:
+  interval: 1000
 wal:
   clean:
     interval: 60000
+lsm:
+  max_records_in_mem_table: 10000
+  max_ro_mem_tables: 1
+  page_size: 4096

--- a/proto/table_service.proto
+++ b/proto/table_service.proto
@@ -21,6 +21,7 @@ message LookupTableRequest {
 
 message LookupTableResponse {
   optional string value = 1;
+  string tx = 2;
 }
 
 message CreateTableRequest {

--- a/src/server/cfg/config.cpp
+++ b/src/server/cfg/config.cpp
@@ -1,6 +1,8 @@
 #include "config.hpp"
 
 #include <chrono>
+#include <cstddef>
+#include <cstdint>
 #include <string>
 #include <stdexcept>
 #include <yaml-cpp/yaml.h>
@@ -41,6 +43,16 @@ Compaction ParseCompaction(const YAML::Node& node) {
   return result;
 }
 
+Flush ParseFlush(const YAML::Node& node) {
+  Flush result{};
+
+  if (node["interval"]) {
+    result.interval = std::chrono::milliseconds{node["interval"].as<int>()};
+  }
+
+  return result;
+}
+
 WalClean ParseWalClean(const YAML::Node& node) {
   WalClean result{};
 
@@ -56,6 +68,22 @@ Wal ParseWal(const YAML::Node& node) {
 
   if (node["clean"]) {
     result.clean = ParseWalClean(node["clean"]);
+  }
+
+  return result;
+}
+
+Lsm ParseLsm(const YAML::Node& node) {
+  Lsm result{};
+
+  if (node["max_records_in_mem_table"]) {
+    result.max_records_in_mem_table = node["max_records_in_mem_table"].as<size_t>();
+  }
+  if (node["max_ro_mem_tables"]) {
+    result.max_ro_mem_tables = node["max_ro_mem_tables"].as<size_t>();
+  }
+  if (node["page_size"]) {
+    result.page_size = node["page_size"].as<int64_t>();
   }
 
   return result;
@@ -83,8 +111,14 @@ Config Parse(const std::string& cfg_path) {
   if (yaml["compaction"]) {
     result.compaction = ParseCompaction(yaml["compaction"]);
   }
+  if (yaml["flush"]) {
+    result.flush = ParseFlush(yaml["flush"]);
+  }
   if (yaml["wal"]) {
     result.wal = ParseWal(yaml["wal"]);
+  }
+  if (yaml["lsm"]) {
+    result.lsm = ParseLsm(yaml["lsm"]);
   }
 
   return result;

--- a/src/server/cfg/config.hpp
+++ b/src/server/cfg/config.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <chrono>
+#include <cstddef>
+#include <cstdint>
 #include <optional>
 #include <string>
 
@@ -28,12 +30,24 @@ struct Compaction {
   std::chrono::milliseconds interval{std::chrono::minutes(1)};
 };
 
+struct Flush {
+  std::chrono::milliseconds interval{std::chrono::seconds(1)};
+};
+
+struct Lsm {
+  size_t max_records_in_mem_table{10000};
+  size_t max_ro_mem_tables{1};
+  int64_t page_size{4096};
+};
+
 struct Config {
   int port{kDefaultPort};
   std::string root{"/tmp/structuredb"};
   Logger logger{};
   Compaction compaction{};
+  Flush flush{};
   Wal wal{};
+  Lsm lsm{};
 };
 
 Config Parse(const std::string& cfg_path);

--- a/src/server/database/context.hpp
+++ b/src/server/database/context.hpp
@@ -3,6 +3,7 @@
 #include <string>
 #include <unordered_map>
 #include <io/manager.hpp>
+#include <lsm/options.hpp>
 #include <table/storage/storage.hpp>
 #include <transaction/storage.hpp>
 #include <wal/writer.hpp>
@@ -13,6 +14,7 @@ namespace structuredb::server::database {
 struct Context {
   io::Manager& io_manager;
   std::string base_dir;
+  lsm::Options lsm_options;
   wal::Writer::Ptr wal_writer;
   std::unordered_map<std::string, table::storage::StorageEngine::Ptr> storages;
   transaction::Storage::Ptr tx_storage;

--- a/src/server/database/database.cpp
+++ b/src/server/database/database.cpp
@@ -3,6 +3,7 @@
 #include <memory>
 #include <string>
 #include <optional>
+#include <vector>
 #include <spdlog/spdlog.h>
 
 #include <table/storage/lsm_storage.hpp>
@@ -19,10 +20,11 @@ const std::string kSysTables = "sys_tables";
 
 }
 
-Database::Database(io::Manager& io_manager, std::string base_dir)
+Database::Database(io::Manager& io_manager, std::string base_dir, lsm::Options lsm_options)
     : context_{
       .io_manager = io_manager,
       .base_dir = base_dir,
+      .lsm_options = lsm_options,
     }
 {}
 
@@ -43,7 +45,7 @@ Awaitable<void> Database::Init() {
   {
     const auto path = context_.base_dir + "/" + kSysTables;
     co_await context_.io_manager.CreateDirectory(path);
-    auto sys_storage = std::make_shared<table::storage::LsmEngine>(context_.io_manager, path, kSysTables);
+    auto sys_storage = std::make_shared<table::storage::LsmEngine>(context_.io_manager, path, kSysTables, context_.lsm_options);
     co_await sys_storage->Init();
     context_.storages.try_emplace(kSysTables, std::move(sys_storage));
   }
@@ -56,7 +58,7 @@ Awaitable<void> Database::Init() {
   // 4. init user tables
   for (const auto& name : dir_content) {
     SPDLOG_INFO("Going to init table {}", name);
-    auto storage = std::make_shared<table::storage::LsmEngine>(context_.io_manager, context_.base_dir + "/" + name, name);
+    auto storage = std::make_shared<table::storage::LsmEngine>(context_.io_manager, context_.base_dir + "/" + name, name, context_.lsm_options);
     co_await storage->Init();
     context_.storages.try_emplace(name, std::move(storage));
   }
@@ -84,6 +86,20 @@ table::storage::DurableStorage::Ptr Database::GetStorageForRecover(const table::
 
 transaction::Storage::Ptr Database::GetTransactionStorage() {
   return context_.tx_storage;
+}
+
+Awaitable<void> Database::Flush() {
+  // snapshot the storages first: the loop below co_awaits, and a concurrent
+  // CreateTable could rehash context_.storages and invalidate iterators
+  std::vector<table::storage::StorageEngine::Ptr> storages;
+  storages.reserve(context_.storages.size());
+  for (const auto& [name, storage] : context_.storages) {
+    storages.push_back(storage);
+  }
+
+  for (const auto& storage : storages) {
+    co_await storage->Flush();
+  }
 }
 
 Awaitable<Session> Database::StartSession(const std::optional<transaction::TransactionId>& tx) {

--- a/src/server/database/database.hpp
+++ b/src/server/database/database.hpp
@@ -3,6 +3,7 @@
 #include <string>
 #include <optional>
 
+#include <lsm/options.hpp>
 #include <table/storage/durable_storage.hpp>
 
 #include "context.hpp"
@@ -13,7 +14,7 @@ namespace structuredb::server::database {
 /// @brief main database class
 class Database {
 public:
- explicit Database(io::Manager& io_manager, std::string base_dir);
+ explicit Database(io::Manager& io_manager, std::string base_dir, lsm::Options lsm_options = {});
 
  Awaitable<void> Init();
 
@@ -21,6 +22,11 @@ public:
  table::storage::DurableStorage::Ptr GetStorageForRecover(const table::storage::StorageEngine::Id& storage_id);
 
  transaction::Storage::Ptr GetTransactionStorage();
+
+ /// @brief persists in-memory data of every table to disk
+ ///
+ /// driven by a background job; keeps the flush off the write path
+ Awaitable<void> Flush();
 
   /// @brief starts session
   ///

--- a/src/server/database/jobs/flush.cpp
+++ b/src/server/database/jobs/flush.cpp
@@ -1,0 +1,24 @@
+#include "flush.hpp"
+
+#include <chrono>
+#include <database/database.hpp>
+#include <spdlog/spdlog.h>
+
+namespace structuredb::server::database {
+
+Flush::Flush(Database& database, const std::chrono::milliseconds interval)
+  : database_{database}
+  , interval_{interval}
+{}
+
+std::chrono::milliseconds Flush::GetInterval() const {
+  return interval_;
+}
+
+Awaitable<void> Flush::Step() {
+  SPDLOG_DEBUG("Flushing database");
+  co_await database_.Flush();
+  SPDLOG_DEBUG("Database flush finished");
+}
+
+}

--- a/src/server/database/jobs/flush.hpp
+++ b/src/server/database/jobs/flush.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <chrono>
+#include <database/context.hpp>
+
+#include <database/jobs/job.hpp>
+
+namespace structuredb::server::database {
+
+class Database;
+
+/// @brief periodically flushes frozen mem tables of every table to disk
+class Flush final : public Job {
+public:
+  explicit Flush(Database& database, const std::chrono::milliseconds interval);
+
+  std::chrono::milliseconds GetInterval() const override;
+
+  Awaitable<void> Step() override;
+private:
+  Database& database_;
+  const std::chrono::milliseconds interval_;
+};
+
+}

--- a/src/server/database/session.cpp
+++ b/src/server/database/session.cpp
@@ -57,7 +57,7 @@ Awaitable<void> Session::CreateTable(const std::string& name) {
     const auto storage_id = co_await catalog.AddStorage(name);
     const auto path = context_.base_dir + "/" + storage_id;
     co_await context_.io_manager.CreateDirectory(path);
-    auto storage = std::make_shared<table::storage::LsmEngine>(context_.io_manager, path, storage_id);
+    auto storage = std::make_shared<table::storage::LsmEngine>(context_.io_manager, path, storage_id, context_.lsm_options);
     co_await storage->Init();
     storage->StartLogInto(context_.wal_writer);
     context_.storages.try_emplace(storage_id, std::move(storage));

--- a/src/server/lsm/lsm.cpp
+++ b/src/server/lsm/lsm.cpp
@@ -29,10 +29,12 @@ int64_t GetSSTableNo(const std::string& file_path) {
 
 }
 
-Lsm::Lsm(io::Manager& io_manager, std::string base_dir)
+Lsm::Lsm(io::Manager& io_manager, std::string base_dir, Options options)
   : io_manager_{io_manager}
   , base_dir_{std::move(base_dir)}
+  , options_{options}
   , shared_mutex_{io_manager_.Context()}
+  , maintenance_mutex_{io_manager_.Context()}
 {}
 
 Awaitable<void> Lsm::Init() {
@@ -74,22 +76,57 @@ Awaitable<void> Lsm::DoPut(const Sequence seq_no, const std::string& key, const 
 
   mem_table_.Put(Record{.key = key, .seq_no = seq_no, .value = value});
 
-  if (mem_table_.Size() > kMaxRecordsInMemTable) {
+  if (mem_table_.Size() > options_.max_records_in_mem_table) {
     SPDLOG_INFO("Mem table reached max size, freeze it");
     ro_mem_tables_.push_back(std::move(mem_table_));
     mem_table_ = MemTable{};
-  }
 
-  if (ro_mem_tables_.size() > kMaxRoMemTables) {
-    SPDLOG_INFO("Ro Mem tables reached max size, flush it");
-    const auto file_path = std::format("{}/{:04d}.sst.sdb", base_dir_, ss_tables_.size());
-    auto ss_table = co_await ro_mem_tables_.front().Flush(io_manager_, file_path);
-    max_persistent_seq_no_ = std::max(max_persistent_seq_no_, ss_table.GetMaxSeqNo());
-    ss_tables_.push_back(std::move(ss_table));
-    ro_mem_tables_.erase(ro_mem_tables_.begin());
+    // The actual flush to disk is done by a background job (see Flush()), so
+    // the write path stays off the disk. If the flusher falls behind, frozen
+    // mem tables pile up in memory - warn so it is observable.
+    if (ro_mem_tables_.size() > options_.max_ro_mem_tables) {
+      SPDLOG_WARN(
+          "Flush is falling behind: {} frozen mem tables in memory (limit {})",
+          ro_mem_tables_.size(), options_.max_ro_mem_tables);
+    }
   }
 
   co_await shared_mutex_.UnlockExclusive();
+}
+
+Awaitable<void> Lsm::Flush() {
+  // serialize against Compact (both mutate ss_tables_)
+  co_await maintenance_mutex_.LockExclusive();
+
+  // How many frozen mem tables to drain in this run. New ones frozen while we
+  // are flushing are left for the next run, so a constant write load cannot
+  // starve this loop.
+  co_await shared_mutex_.LockShared();
+  auto pending = ro_mem_tables_.size();
+  co_await shared_mutex_.UnlockShared();
+
+  while (pending > 0) {
+    // The front frozen mem table is immutable: the write path only appends new
+    // frozen tables (std::deque never invalidates references on push_back) and
+    // this single, sequentially-run job is the only place that pops them. So
+    // the slow disk write below can run without holding any lock, keeping the
+    // write path (which needs the exclusive lock) unblocked.
+    const auto file_path = std::format("{}/{:04d}.sst.sdb", base_dir_, ss_tables_.size());
+    auto ss_table = co_await ro_mem_tables_.front().Flush(io_manager_, file_path, options_.page_size);
+
+    // Publish the new ss table and drop the now-persisted mem table atomically.
+    // The mem table stays readable (in ro_mem_tables_) for the whole flush, so
+    // concurrent reads never lose its keys.
+    co_await shared_mutex_.LockExclusive();
+    max_persistent_seq_no_ = std::max(max_persistent_seq_no_, ss_table.GetMaxSeqNo());
+    ss_tables_.push_back(std::move(ss_table));
+    ro_mem_tables_.pop_front();
+    co_await shared_mutex_.UnlockExclusive();
+
+    --pending;
+  }
+
+  co_await maintenance_mutex_.UnlockExclusive();
 }
 
 Awaitable<std::optional<std::string>> Lsm::Get(const std::string& key) {
@@ -120,7 +157,9 @@ Awaitable<Iterator::Ptr> Lsm::Scan(const ScanRange& range) {
 Awaitable<void> Lsm::Compact(CompactionStrategy::Ptr strategy) {
   SPDLOG_INFO("Compaction started");
 
-  constexpr static const int64_t kPageSize = 512;
+  // serialize against background Flush so ss_tables_ is not mutated underneath
+  // the scan/merge below
+  co_await maintenance_mutex_.LockExclusive();
 
   std::vector<std::string> files_to_delete;
   files_to_delete.reserve(ss_tables_.size());
@@ -144,7 +183,7 @@ Awaitable<void> Lsm::Compact(CompactionStrategy::Ptr strategy) {
   {
     SPDLOG_INFO("SSTableBuilder started");
     auto file_writer = co_await io_manager_.CreateFileWriter(file_path);
-    auto builder = co_await disk::SSTableBuilder::Create(file_writer, kPageSize);
+    auto builder = co_await disk::SSTableBuilder::Create(file_writer, options_.page_size);
     co_await strategy->CompactRecords(merge_iterator, builder);
     co_await std::move(builder).Finish();
     SPDLOG_INFO("SSTableBuilder finished");
@@ -161,6 +200,8 @@ Awaitable<void> Lsm::Compact(CompactionStrategy::Ptr strategy) {
   for (const auto& path : files_to_delete) {
     co_await io_manager_.Remove(path);
   }
+
+  co_await maintenance_mutex_.UnlockExclusive();
 
   SPDLOG_INFO("Compaction finished, new ss_tables count: {}", ss_tables_.size());
 }

--- a/src/server/lsm/lsm.hpp
+++ b/src/server/lsm/lsm.hpp
@@ -13,6 +13,7 @@
 #include "iterators/iterator.hpp"
 #include "compaction/compact_strategy.hpp"
 #include "mem_table.hpp"
+#include "options.hpp"
 #include "ss_table.hpp"
 
 namespace structuredb::server::lsm {
@@ -20,7 +21,7 @@ namespace structuredb::server::lsm {
 /// @brief Log Structure Merge Tree
 class Lsm {
 public:
-  explicit Lsm(io::Manager& io_manager, std::string base_dir);
+  explicit Lsm(io::Manager& io_manager, std::string base_dir, Options options = {});
 
   Awaitable<void> Init();
 
@@ -48,15 +49,24 @@ public:
 
   Awaitable<void> Compact(CompactionStrategy::Ptr strategy);
 
+  /// @brief persists frozen (read-only) mem tables to ss tables
+  ///
+  /// Intended to be driven by a background job: the write path only freezes
+  /// the active mem table, the actual disk write happens here off the
+  /// critical path.
+  Awaitable<void> Flush();
+
   int CountSSTables() const;
 private:
-  constexpr static const size_t kMaxRecordsInMemTable{50};
-
-  constexpr static const size_t kMaxRoMemTables{1};
-
   io::Manager& io_manager_;
   const std::string base_dir_{};
+  const Options options_{};
+  // guards mem_table_ / ro_mem_tables_ / ss_tables_ against concurrent
+  // readers and writers
   io::SharedMutex shared_mutex_;
+  // serializes background maintenance (Flush vs Compact) on this lsm so they
+  // never mutate ss_tables_ at the same time
+  io::SharedMutex maintenance_mutex_;
 
   MemTable mem_table_;
   std::deque<MemTable> ro_mem_tables_{};

--- a/src/server/lsm/mem_table.cpp
+++ b/src/server/lsm/mem_table.cpp
@@ -21,16 +21,14 @@ size_t MemTable::Size() const {
 
 }
 
-Awaitable<SSTable> MemTable::Flush(io::Manager& io_manager, const std::string& file_path) const {
-  constexpr static const int64_t kPageSize = 512;
-
+Awaitable<SSTable> MemTable::Flush(io::Manager& io_manager, const std::string& file_path, int64_t page_size) const {
   SPDLOG_INFO("MemTable flush started");
 
   // This bock is important because
   // file_writer closes file in destructor
   {
     auto file_writer = co_await io_manager.CreateFileWriter(file_path);
-    auto builder = co_await disk::SSTableBuilder::Create(file_writer, kPageSize);
+    auto builder = co_await disk::SSTableBuilder::Create(file_writer, page_size);
     for (const auto& record : impl_) {
       co_await builder.Add(record);
     }

--- a/src/server/lsm/mem_table.hpp
+++ b/src/server/lsm/mem_table.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstddef>
+#include <cstdint>
 #include <string>
 #include <set>
 
@@ -25,7 +26,7 @@ public:
   /// @brief creates SSTable based on current MemTable
   ///
   /// (Persists MemTable data on disk)
-  Awaitable<SSTable> Flush(io::Manager& io_manager, const std::string& file_path) const;
+  Awaitable<SSTable> Flush(io::Manager& io_manager, const std::string& file_path, int64_t page_size) const;
 
   /// @returns iterator to scan given @p range
   Iterator::Ptr Scan(const ScanRange& range) const;

--- a/src/server/lsm/options.hpp
+++ b/src/server/lsm/options.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+namespace structuredb::server::lsm {
+
+/// @brief tunable LSM tree parameters
+struct Options {
+  /// @brief max records in the active mem table before it is frozen
+  size_t max_records_in_mem_table{10000};
+
+  /// @brief max read-only mem tables kept in memory before the oldest is
+  /// flushed to disk
+  size_t max_ro_mem_tables{1};
+
+  /// @brief size of a page in bytes used when writing sstable files
+  ///
+  /// a single record (key + value + per-record overhead) must fit into one
+  /// page, so this also caps the maximum record size
+  int64_t page_size{4096};
+};
+
+}

--- a/src/server/main.cpp
+++ b/src/server/main.cpp
@@ -22,9 +22,11 @@
 #include <cfg/config.hpp>
 #include <database/database.hpp>
 #include <database/jobs/compaction.hpp>
+#include <database/jobs/flush.hpp>
 #include <database/jobs/job_launcher.hpp>
 #include <database/jobs/wal_cleaner.hpp>
 #include <io/manager.hpp>
+#include <lsm/options.hpp>
 
 ABSL_FLAG(std::string, config, "./config.yaml", "Path to config");
 
@@ -77,7 +79,12 @@ int main(int argc, char** argv) {
     boost::asio::io_context io_context{};
     structuredb::server::io::Manager io_manager{io_context};
 
-    structuredb::server::database::Database database{io_manager, config.root};
+    const structuredb::server::lsm::Options lsm_options{
+      .max_records_in_mem_table = config.lsm.max_records_in_mem_table,
+      .max_ro_mem_tables = config.lsm.max_ro_mem_tables,
+      .page_size = config.lsm.page_size,
+    };
+    structuredb::server::database::Database database{io_manager, config.root, lsm_options};
     auto init_future = boost::asio::co_spawn(io_context, Init(database), boost::asio::use_future);
 
     const auto table_service = structuredb::server::services::MakeService(io_manager, database);
@@ -102,6 +109,7 @@ int main(int argc, char** argv) {
     // background jobs
     structuredb::server::database::JobLauncher job_launcher{io_manager};
     job_launcher.Launch(std::make_shared<structuredb::server::database::Compaction>(database, config.compaction.interval));
+    job_launcher.Launch(std::make_shared<structuredb::server::database::Flush>(database, config.flush.interval));
     job_launcher.Launch(std::make_shared<structuredb::server::database::WalCleaner>(io_manager, database, config.root + "/wal", config.wal.clean.interval));
 
     // server

--- a/src/server/services/table_service/table_service.cpp
+++ b/src/server/services/table_service/table_service.cpp
@@ -22,8 +22,6 @@ grpc::ServerUnaryReactor* TableServiceImpl::Upsert(
   auto* reactor = context->DefaultReactor();
 
   io_manager_.CoSpawn([this, request, response, reactor]() -> Awaitable<void> {
-      std::unique_lock lock{mu_};
-
       try {
         const auto tx = rpc::ParseTx(request);
         auto session = co_await database_.StartSession(tx);
@@ -56,8 +54,6 @@ grpc::ServerUnaryReactor* TableServiceImpl::Lookup(
   auto* reactor = context->DefaultReactor();
 
   io_manager_.CoSpawn([this, reactor, request, response]() -> Awaitable<void> {
-      std::unique_lock lock{mu_};
-
       try {
         const auto tx = rpc::ParseTx(request);
         auto session = co_await database_.StartSession(tx);
@@ -75,6 +71,7 @@ grpc::ServerUnaryReactor* TableServiceImpl::Lookup(
         }
 
         auto result_tx = co_await session.Finish();
+        response->set_tx(transaction::ToString(result_tx));
         reactor->Finish(grpc::Status::OK);
       } catch (const std::exception& e) {
         reactor->Finish(rpc::MakeInternalError(e.what()));
@@ -92,8 +89,6 @@ grpc::ServerUnaryReactor* TableServiceImpl::Delete(
   auto* reactor = context->DefaultReactor();
 
   io_manager_.CoSpawn([this, request, response, reactor]() -> Awaitable<void> {
-      std::unique_lock lock{mu_};
-
       try {
         const auto tx = rpc::ParseTx(request);
         auto session = co_await database_.StartSession(tx);
@@ -126,8 +121,6 @@ grpc::ServerUnaryReactor* TableServiceImpl::CreateTable(
   auto* reactor = context->DefaultReactor();
 
   io_manager_.CoSpawn([this, request, response, reactor]() -> Awaitable<void> {
-      std::unique_lock lock{mu_};
-
       try {
         const auto tx = rpc::ParseTx(request);
         auto session = co_await database_.StartSession(tx);
@@ -155,8 +148,6 @@ grpc::ServerUnaryReactor* TableServiceImpl::DropTable(
   auto* reactor = context->DefaultReactor();
 
   io_manager_.CoSpawn([this, request, response, reactor]() -> Awaitable<void> {
-      std::unique_lock lock{mu_};
-
       try {
         const auto tx = rpc::ParseTx(request);
         auto session = co_await database_.StartSession(tx);
@@ -184,8 +175,6 @@ grpc::ServerUnaryReactor* TableServiceImpl::Scan(
   auto* reactor = context->DefaultReactor();
 
   io_manager_.CoSpawn([this, request, response, reactor]() -> Awaitable<void> {
-      std::unique_lock lock{mu_};
-
       try {
         const auto tx = rpc::ParseTx(request);
         auto session = co_await database_.StartSession(tx);
@@ -232,8 +221,6 @@ grpc::ServerUnaryReactor* TableServiceImpl::CompactTable(
   auto* reactor = context->DefaultReactor();
 
   io_manager_.CoSpawn([this, request, response, reactor]() -> Awaitable<void> {
-      std::unique_lock lock{mu_};
-
       try {
         const auto tx = rpc::ParseTx(request);
         auto session = co_await database_.StartSession(tx);

--- a/src/server/services/table_service/table_service.hpp
+++ b/src/server/services/table_service/table_service.hpp
@@ -57,8 +57,6 @@ public:
 private:
   io::Manager& io_manager_;
   database::Database& database_;
-  std::mutex mu_;
-
 };
 
 std::unique_ptr<grpc::Service> MakeService(

--- a/src/server/table/storage/lsm_storage.cpp
+++ b/src/server/table/storage/lsm_storage.cpp
@@ -86,8 +86,8 @@ private:
 
 }
 
-LsmEngine::LsmEngine(io::Manager& io_manager, std::string base_dir, std::string id)
-  : lsm_{io_manager, std::move(base_dir)}, id_{std::move(id)}
+LsmEngine::LsmEngine(io::Manager& io_manager, std::string base_dir, std::string id, lsm::Options lsm_options)
+  : lsm_{io_manager, std::move(base_dir), lsm_options}, id_{std::move(id)}
 {}
 
 Awaitable<void> LsmEngine::Init() {
@@ -131,8 +131,12 @@ Awaitable<Iterator::Ptr> LsmEngine::Scan(const std::optional<std::string>& lower
   co_return std::make_shared<LsmEngineIterator>(std::move(result));
 }
 
-Awaitable<void> LsmEngine::Compact(CompactionStrategy::Ptr strategy) { 
+Awaitable<void> LsmEngine::Compact(CompactionStrategy::Ptr strategy) {
   co_await lsm_.Compact(std::make_shared<LsmEngineCompactStrategy>(std::move(strategy)));
+}
+
+Awaitable<void> LsmEngine::Flush() {
+  co_await lsm_.Flush();
 }
 
 int LsmEngine::CountSSTables() const {

--- a/src/server/table/storage/lsm_storage.hpp
+++ b/src/server/table/storage/lsm_storage.hpp
@@ -24,7 +24,7 @@ class LsmEngine : public StorageEngine, public DurableStorage {
 public:
   using Ptr = std::shared_ptr<LsmEngine>;
 
-  explicit LsmEngine(io::Manager& io_manager, std::string base_dir, StorageEngine::Id id);
+  explicit LsmEngine(io::Manager& io_manager, std::string base_dir, StorageEngine::Id id, lsm::Options lsm_options = {});
 
   Awaitable<void> Init();
 
@@ -41,6 +41,8 @@ public:
   Awaitable<Iterator::Ptr> Scan(const std::optional<std::string>& lower_bound, const std::optional<std::string>& upper_bound) override;
 
   Awaitable<void> Compact(CompactionStrategy::Ptr strategy) override;
+
+  Awaitable<void> Flush() override;
 
   /// @brief number of on-disk SSTables — LSM-specific statistic, not part of
   /// the engine interface; callers must downcast to query it

--- a/src/server/table/storage/storage.hpp
+++ b/src/server/table/storage/storage.hpp
@@ -49,6 +49,9 @@ public:
   /// @brief runs optimization of storage
   virtual Awaitable<void> Compact(CompactionStrategy::Ptr strategy) = 0;
 
+  /// @brief persists in-memory data to disk (off the write path)
+  virtual Awaitable<void> Flush() { co_return; }
+
   virtual ~StorageEngine() = default;
 };
 

--- a/tests/server/database/common.hpp
+++ b/tests/server/database/common.hpp
@@ -14,6 +14,7 @@
 #include <boost/asio/use_future.hpp>
 
 #include <database/database.hpp>
+#include <lsm/options.hpp>
 #include <spdlog/spdlog.h>
 
 namespace structuredb::tests {
@@ -28,9 +29,17 @@ protected:
     assert(std::filesystem::create_directory(tmp_dir_));
 
     io_manager_ = std::make_unique<server::io::Manager>(io_context_);
+    // small thresholds so tests deterministically trigger freezes/flushes
+    // without depending on the production defaults
+    const server::lsm::Options lsm_options{
+        .max_records_in_mem_table = 50,
+        .max_ro_mem_tables = 1,
+        .page_size = 512,
+    };
     db_ = std::make_unique<server::database::Database>(
         *io_manager_,
-        tmp_dir_
+        tmp_dir_,
+        lsm_options
     );
 
     asio_thread_ = std::thread([this]() {

--- a/tests/server/database/database_test.cpp
+++ b/tests/server/database/database_test.cpp
@@ -216,6 +216,11 @@ DATABASE_TEST(Compaction, {
     co_await session.Finish();
   }
 
+  // flushing is done off the write path by a background job, which is not
+  // running in tests - trigger it explicitly so frozen mem tables become
+  // ss tables
+  co_await db.Flush();
+
   {
     auto session = co_await db.StartSession();
     auto table = co_await session.GetTable(kTableName);


### PR DESCRIPTION
## Summary

Refactors the LSM/server around three related changes (see commits for the split):

### 1. Configurable LSM limits
Previously hardcoded constants are now tunable via `lsm::Options`, threaded from `config.yaml` → `Database` → `LsmStorage` → `Lsm`:
- `max_records_in_mem_table` (was `kMaxRecordsInMemTable`)
- `max_ro_mem_tables` (was `kMaxRoMemTables`)
- `page_size` (was `kPageSize`, defined twice)

Defaults bumped from toy values `50 / 1 / 512` to `10000 / 1 / 4096`. Note: `page_size` caps the maximum encoded record size (a record must fit in one page), so 512 was dangerously small.

### 2. Background flush job
The memtable→SSTable flush was done **inline in `DoPut`** once the read-only memtable limit was hit, stalling every Nth write under the exclusive lock. Now:
- `DoPut` only **freezes** the active memtable (cheap, in-memory).
- A new background `Flush` job drains frozen memtables to disk, doing the slow I/O **without holding the write lock**, then publishing the new SSTable under a brief exclusive section. The frozen memtable stays readable throughout, so reads never miss keys.
- A dedicated `maintenance_mutex_` serializes `Flush` vs `Compact` so they never mutate `ss_tables_` concurrently.
- Flush interval is configurable (`cfg::Flush`, default 1s).

### 3. table-service cleanup
- **Removed the per-service `std::mutex`**: it was held across `co_await` on a single-threaded `io_context`, which deadlocks as soon as two RPCs overlap and otherwise serializes the entire service. Concurrency is already handled by transaction row locks/MVCC and the LSM's async `SharedMutex`.
- **`Lookup` now returns `tx`**: it computed `result_tx` but never sent it, unlike the other session-finishing RPCs. Added a `tx` field to `LookupTableResponse` (additive proto change) and set it, matching `Scan`.

## Known follow-ups (out of scope)
- No hard write-stall **backpressure**: under sustained overload (writes faster than the flusher) frozen memtables accumulate in memory — currently only a `WARN` when exceeding `max_ro_mem_tables`. Blocking/slowing `Put` until the flusher catches up is a natural next step.
- `max_records_in_mem_table` is counted in **records, not bytes**, so memtable memory footprint depends on value sizes.

## Testing
- `make build` clean.
- `make tests` — all pass. The `Compaction` test triggers flush explicitly via `Database::Flush()` (background jobs don't run in the test harness); the test fixture uses small LSM limits for deterministic freezes/flushes.
- gRPC service layer is not covered by the existing tests (they drive `Database` directly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)