### PR TITLE
feat(cache): add LRU page cache for SSTable

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -14,3 +14,4 @@ lsm:
   max_records_in_mem_table: 10000
   max_ro_mem_tables: 1
   page_size: 4096
+  page_cache_capacity: 1024

--- a/src/server/cache/lru_cache.hpp
+++ b/src/server/cache/lru_cache.hpp
@@ -1,0 +1,96 @@
+#pragma once
+
+#include <cstddef>
+#include <list>
+#include <unordered_map>
+#include <utility>
+
+namespace structuredb::server::cache {
+
+/// @brief fixed-capacity Least-Recently-Used cache
+///
+/// Keeps at most @c capacity entries. Reading (Get) or writing (Put) an entry
+/// marks it most-recently-used; once the cache is full, inserting a new key
+/// evicts the least-recently-used entry.
+///
+/// Lookup, insertion and eviction are all O(1): a doubly linked list keeps the
+/// usage order (most-recently-used at the front) while a hash map gives direct
+/// access to each list node.
+///
+/// @note Not thread-safe. Intended for the single-threaded cooperative
+///       coroutine model used across the server: the io_context runs one
+///       coroutine at a time, so the maps are only touched between co_await
+///       points and no std::mutex is needed. Do not hold a returned pointer
+///       across a co_await that may mutate the same cache.
+template <typename Key, typename Value>
+class LruCache {
+public:
+  explicit LruCache(size_t capacity) : capacity_{capacity} {}
+
+  /// @brief looks up @p key, marking it most-recently-used on hit
+  /// @returns pointer to the stored value, or nullptr if the key is absent
+  ///
+  /// The returned pointer stays valid until the next mutating call on the
+  /// cache (a Put, or another Get is fine — only Put can evict).
+  Value* Get(const Key& key) {
+    auto it = index_.find(key);
+    if (it == index_.end()) {
+      return nullptr;
+    }
+    // move the touched node to the front (most-recently-used)
+    entries_.splice(entries_.begin(), entries_, it->second);
+    return &it->second->second;
+  }
+
+  /// @brief inserts or updates @p key, marking it most-recently-used
+  ///
+  /// Evicts the least-recently-used entry if the cache exceeds its capacity.
+  void Put(const Key& key, Value value) {
+    if (capacity_ == 0) {
+      return;
+    }
+
+    auto it = index_.find(key);
+    if (it != index_.end()) {
+      it->second->second = std::move(value);
+      entries_.splice(entries_.begin(), entries_, it->second);
+      return;
+    }
+
+    entries_.emplace_front(key, std::move(value));
+    index_[key] = entries_.begin();
+
+    if (index_.size() > capacity_) {
+      // evict least-recently-used (the back of the list)
+      index_.erase(entries_.back().first);
+      entries_.pop_back();
+    }
+  }
+
+  bool Contains(const Key& key) const {
+    return index_.contains(key);
+  }
+
+  size_t Size() const {
+    return index_.size();
+  }
+
+  size_t Capacity() const {
+    return capacity_;
+  }
+
+  void Clear() {
+    entries_.clear();
+    index_.clear();
+  }
+
+private:
+  using Entry = std::pair<Key, Value>;
+
+  // most-recently-used at the front, least-recently-used at the back
+  std::list<Entry> entries_;
+  std::unordered_map<Key, typename std::list<Entry>::iterator> index_;
+  size_t capacity_;
+};
+
+}

--- a/src/server/cfg/config.cpp
+++ b/src/server/cfg/config.cpp
@@ -85,6 +85,9 @@ Lsm ParseLsm(const YAML::Node& node) {
   if (node["page_size"]) {
     result.page_size = node["page_size"].as<int64_t>();
   }
+  if (node["page_cache_capacity"]) {
+    result.page_cache_capacity = node["page_cache_capacity"].as<size_t>();
+  }
 
   return result;
 }

--- a/src/server/cfg/config.hpp
+++ b/src/server/cfg/config.hpp
@@ -38,6 +38,7 @@ struct Lsm {
   size_t max_records_in_mem_table{10000};
   size_t max_ro_mem_tables{1};
   int64_t page_size{4096};
+  size_t page_cache_capacity{1024};
 };
 
 struct Config {

--- a/src/server/lsm/lsm.cpp
+++ b/src/server/lsm/lsm.cpp
@@ -43,7 +43,7 @@ Awaitable<void> Lsm::Init() {
   std::ranges::sort(names);
   for (const auto& name : names) {
     auto file_reader = co_await io_manager_.CreateFileReader(base_dir_ + "/" + name);
-    auto ss_table = co_await SSTable::Create(std::move(file_reader));
+    auto ss_table = co_await SSTable::Create(std::move(file_reader), options_.page_cache_capacity);
     max_persistent_seq_no_ = std::max(max_persistent_seq_no_, ss_table.GetMaxSeqNo());
     ss_tables_.push_back(std::move(ss_table));
   }
@@ -112,7 +112,7 @@ Awaitable<void> Lsm::Flush() {
     // the slow disk write below can run without holding any lock, keeping the
     // write path (which needs the exclusive lock) unblocked.
     const auto file_path = std::format("{}/{:04d}.sst.sdb", base_dir_, ss_tables_.size());
-    auto ss_table = co_await ro_mem_tables_.front().Flush(io_manager_, file_path, options_.page_size);
+    auto ss_table = co_await ro_mem_tables_.front().Flush(io_manager_, file_path, options_.page_size, options_.page_cache_capacity);
 
     // Publish the new ss table and drop the now-persisted mem table atomically.
     // The mem table stays readable (in ro_mem_tables_) for the whole flush, so
@@ -190,7 +190,7 @@ Awaitable<void> Lsm::Compact(CompactionStrategy::Ptr strategy) {
   }
 
   auto file_reader = co_await io_manager_.CreateFileReader(file_path);
-  auto ss_table = co_await SSTable::Create(std::move(file_reader));
+  auto ss_table = co_await SSTable::Create(std::move(file_reader), options_.page_cache_capacity);
 
   co_await shared_mutex_.LockExclusive();
   ss_tables_.clear();

--- a/src/server/lsm/mem_table.cpp
+++ b/src/server/lsm/mem_table.cpp
@@ -21,7 +21,7 @@ size_t MemTable::Size() const {
 
 }
 
-Awaitable<SSTable> MemTable::Flush(io::Manager& io_manager, const std::string& file_path, int64_t page_size) const {
+Awaitable<SSTable> MemTable::Flush(io::Manager& io_manager, const std::string& file_path, int64_t page_size, size_t page_cache_capacity) const {
   SPDLOG_INFO("MemTable flush started");
 
   // This bock is important because
@@ -37,7 +37,7 @@ Awaitable<SSTable> MemTable::Flush(io::Manager& io_manager, const std::string& f
   }
 
   auto file_reader = co_await io_manager.CreateFileReader(file_path);
-  auto ss_table = co_await SSTable::Create(std::move(file_reader));
+  auto ss_table = co_await SSTable::Create(std::move(file_reader), page_cache_capacity);
   co_return ss_table;
 }
 

--- a/src/server/lsm/mem_table.hpp
+++ b/src/server/lsm/mem_table.hpp
@@ -26,7 +26,7 @@ public:
   /// @brief creates SSTable based on current MemTable
   ///
   /// (Persists MemTable data on disk)
-  Awaitable<SSTable> Flush(io::Manager& io_manager, const std::string& file_path, int64_t page_size) const;
+  Awaitable<SSTable> Flush(io::Manager& io_manager, const std::string& file_path, int64_t page_size, size_t page_cache_capacity) const;
 
   /// @returns iterator to scan given @p range
   Iterator::Ptr Scan(const ScanRange& range) const;

--- a/src/server/lsm/options.hpp
+++ b/src/server/lsm/options.hpp
@@ -19,6 +19,12 @@ struct Options {
   /// a single record (key + value + per-record overhead) must fit into one
   /// page, so this also caps the maximum record size
   int64_t page_size{4096};
+
+  /// @brief max pages cached in memory per sstable file
+  ///
+  /// each sstable keeps an LRU cache of decoded pages to avoid re-reading hot
+  /// pages from disk; 0 disables caching
+  size_t page_cache_capacity{1024};
 };
 
 }

--- a/src/server/lsm/ss_table.cpp
+++ b/src/server/lsm/ss_table.cpp
@@ -7,22 +7,21 @@
 #include <vector>
 #include <spdlog/spdlog.h>
 
-#include <utils/find.hpp>
-
 #include <sdb/buffer_reader.hpp>
 
 #include "iterators/ss_table_iterator.hpp"
 
 namespace structuredb::server::lsm {
 
-Awaitable<SSTable> SSTable::Create(io::FileReader::Ptr file_reader) {
-  SSTable result{std::move(file_reader)};
+Awaitable<SSTable> SSTable::Create(io::FileReader::Ptr file_reader, size_t page_cache_capacity) {
+  SSTable result{std::move(file_reader), page_cache_capacity};
   co_await result.Init();
   co_return result;
 }
 
-SSTable::SSTable(io::FileReader::Ptr file_reader)
+SSTable::SSTable(io::FileReader::Ptr file_reader, size_t page_cache_capacity)
   : file_reader_{std::move(file_reader)}
+  , page_cache_{page_cache_capacity}
 {}
 
 Awaitable<void> SSTable::Init() {
@@ -65,17 +64,19 @@ Sequence SSTable::GetMaxSeqNo() const {
 
 Awaitable<disk::Page::Ptr> SSTable::GetPage(int64_t page_num) {
   assert(page_num < header_.page_count);
-  co_await file_reader_->Seek(header_size_ + page_num * header_.page_size);
 
-  const auto* cached = utils::FindOrNullptr(page_cache_, page_num);
-  if (cached) {
+  const auto key = static_cast<size_t>(page_num);
+  if (auto* cached = page_cache_.Get(key)) {
     co_return *cached;
   }
 
+  co_await file_reader_->Seek(header_size_ + page_num * header_.page_size);
   std::vector<char> buffer(header_.page_size);
   co_await file_reader_->Read(buffer.data(), buffer.size());
-  page_cache_[page_num] = disk::Page::Load(std::move(buffer));
-  co_return page_cache_[page_num];
+
+  auto page = disk::Page::Load(std::move(buffer));
+  page_cache_.Put(key, page);
+  co_return page;
 }
 
 const std::string& SSTable::GetFilePath() const {

--- a/src/server/lsm/ss_table.hpp
+++ b/src/server/lsm/ss_table.hpp
@@ -1,10 +1,11 @@
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
-#include <unordered_map>
 #include <string>
 
 #include <io/file_reader.hpp>
+#include <cache/lru_cache.hpp>
 
 #include "disk/page.hpp"
 #include "disk/ss_table_header.hpp"
@@ -19,7 +20,7 @@ namespace structuredb::server::lsm {
 /// Also file is divided on pages
 class SSTable {
 public:
-  static Awaitable<SSTable> Create(io::FileReader::Ptr file_reader);
+  static Awaitable<SSTable> Create(io::FileReader::Ptr file_reader, size_t page_cache_capacity);
 
   /// @returns iterator to scan given @p range
   Awaitable<Iterator::Ptr> Scan(const ScanRange& range);
@@ -31,7 +32,7 @@ public:
 
   const std::string& GetFilePath() const;
 private:
-  explicit SSTable(io::FileReader::Ptr file_reader);
+  explicit SSTable(io::FileReader::Ptr file_reader, size_t page_cache_capacity);
 
   Awaitable<void> Init();
 
@@ -51,8 +52,7 @@ private:
   int64_t header_size_{};
   disk::Page page_{};
 
-  /// TODO use lru cache
-  std::unordered_map<size_t, disk::Page::Ptr> page_cache_;
+  cache::LruCache<size_t, disk::Page::Ptr> page_cache_;
 
   /// @brief returns page by its number
   Awaitable<disk::Page::Ptr> GetPage(int64_t page_num);

--- a/src/server/main.cpp
+++ b/src/server/main.cpp
@@ -83,6 +83,7 @@ int main(int argc, char** argv) {
       .max_records_in_mem_table = config.lsm.max_records_in_mem_table,
       .max_ro_mem_tables = config.lsm.max_ro_mem_tables,
       .page_size = config.lsm.page_size,
+      .page_cache_capacity = config.lsm.page_cache_capacity,
     };
     structuredb::server::database::Database database{io_manager, config.root, lsm_options};
     auto init_future = boost::asio::co_spawn(io_context, Init(database), boost::asio::use_future);

--- a/tests/server/cache/lru_cache_test.cpp
+++ b/tests/server/cache/lru_cache_test.cpp
@@ -1,0 +1,111 @@
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include <cache/lru_cache.hpp>
+
+namespace structuredb::tests {
+
+using structuredb::server::cache::LruCache;
+
+TEST(LruCacheTest, MissOnEmpty) {
+  LruCache<int, std::string> cache{2};
+  EXPECT_EQ(cache.Get(1), nullptr);
+  EXPECT_EQ(cache.Size(), 0u);
+}
+
+TEST(LruCacheTest, PutThenGet) {
+  LruCache<int, std::string> cache{2};
+  cache.Put(1, "one");
+
+  auto* value = cache.Get(1);
+  ASSERT_NE(value, nullptr);
+  EXPECT_EQ(*value, "one");
+  EXPECT_EQ(cache.Size(), 1u);
+}
+
+TEST(LruCacheTest, PutOverwritesExisting) {
+  LruCache<int, std::string> cache{2};
+  cache.Put(1, "one");
+  cache.Put(1, "ONE");
+
+  auto* value = cache.Get(1);
+  ASSERT_NE(value, nullptr);
+  EXPECT_EQ(*value, "ONE");
+  EXPECT_EQ(cache.Size(), 1u);
+}
+
+TEST(LruCacheTest, EvictsLeastRecentlyUsed) {
+  LruCache<int, std::string> cache{2};
+  cache.Put(1, "one");
+  cache.Put(2, "two");
+  cache.Put(3, "three");  // evicts key 1 (least-recently-used)
+
+  EXPECT_EQ(cache.Get(1), nullptr);
+  ASSERT_NE(cache.Get(2), nullptr);
+  ASSERT_NE(cache.Get(3), nullptr);
+  EXPECT_EQ(cache.Size(), 2u);
+}
+
+TEST(LruCacheTest, GetRefreshesRecency) {
+  LruCache<int, std::string> cache{2};
+  cache.Put(1, "one");
+  cache.Put(2, "two");
+
+  // touch key 1 so key 2 becomes least-recently-used
+  ASSERT_NE(cache.Get(1), nullptr);
+
+  cache.Put(3, "three");  // evicts key 2, not key 1
+
+  ASSERT_NE(cache.Get(1), nullptr);
+  EXPECT_EQ(cache.Get(2), nullptr);
+  ASSERT_NE(cache.Get(3), nullptr);
+}
+
+TEST(LruCacheTest, OverwriteRefreshesRecency) {
+  LruCache<int, std::string> cache{2};
+  cache.Put(1, "one");
+  cache.Put(2, "two");
+  cache.Put(1, "one-again");  // refreshes key 1
+  cache.Put(3, "three");      // evicts key 2
+
+  ASSERT_NE(cache.Get(1), nullptr);
+  EXPECT_EQ(cache.Get(2), nullptr);
+  ASSERT_NE(cache.Get(3), nullptr);
+}
+
+TEST(LruCacheTest, ZeroCapacityCachesNothing) {
+  LruCache<int, std::string> cache{0};
+  cache.Put(1, "one");
+
+  EXPECT_EQ(cache.Get(1), nullptr);
+  EXPECT_EQ(cache.Size(), 0u);
+  EXPECT_EQ(cache.Capacity(), 0u);
+}
+
+TEST(LruCacheTest, ContainsDoesNotChangeRecency) {
+  LruCache<int, std::string> cache{2};
+  cache.Put(1, "one");
+  cache.Put(2, "two");
+
+  // Contains must not refresh key 1, so it stays the eviction victim
+  EXPECT_TRUE(cache.Contains(1));
+  cache.Put(3, "three");
+
+  EXPECT_FALSE(cache.Contains(1));
+  EXPECT_TRUE(cache.Contains(2));
+  EXPECT_TRUE(cache.Contains(3));
+}
+
+TEST(LruCacheTest, Clear) {
+  LruCache<int, std::string> cache{2};
+  cache.Put(1, "one");
+  cache.Put(2, "two");
+  cache.Clear();
+
+  EXPECT_EQ(cache.Size(), 0u);
+  EXPECT_EQ(cache.Get(1), nullptr);
+  EXPECT_EQ(cache.Get(2), nullptr);
+}
+
+}


### PR DESCRIPTION
## Summary
Replaces the unbounded `std::unordered_map` page cache in `SSTable` with a proper fixed-capacity LRU cache, resolving the long-standing `// TODO use lru cache`. Previously every page read was cached forever with no eviction.

## Changes
- **New `cache::LruCache<Key, Value>`** (`src/server/cache/lru_cache.hpp`) — generic, header-only. O(1) `Get`/`Put`/evict via an intrusive `std::list` (usage order) + `std::unordered_map` (node lookup). Not thread-safe by design — matches the single-threaded cooperative coroutine model (one coroutine at a time on the `io_context`, no `std::mutex` needed).
- **Wired into `SSTable`** — `page_cache_` is now an `LruCache`. `GetPage` checks the cache *before* seeking/reading (the old code always seeked, even on a cache hit).
- **Configurable capacity** — `lsm.page_cache_capacity` (default `1024` pages ≈ 4 MB per sstable at `page_size=4096`) plumbed through `lsm::Options`, `cfg::Lsm`, `config.cpp`, `main.cpp` and `config.yaml`. `0` disables caching.
- **Tests** — `tests/server/cache/lru_cache_test.cpp`: 9 cases covering LRU eviction, recency refresh on `Get`/`Put`, `Contains` not affecting recency, zero capacity, and `Clear`.

## Notes
Capacity is **per sstable file**, not a global memory budget. A shared cross-table cache with a single budget would be a separate follow-up.

## Testing
- `make build` — clean
- `ctest` — all tests pass, including the 9 new LRU cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)