### PR TITLE
feat(cli): add ROLLBACK command

### DIFF
--- a/src/cli/command/command.cpp
+++ b/src/cli/command/command.cpp
@@ -123,6 +123,31 @@ public:
   }
 };
 
+class RollbackCommand : public Command {
+public:
+  constexpr static const char* kName = "ROLLBACK";
+  constexpr static const char* kHints = "";
+
+  static Command::Ptr TryParse(const std::vector<std::string>& tokens) {
+    if (!tokens.empty() && tokens[0] == "ROLLBACK") {
+      if (tokens.size() != 1) {
+        throw std::runtime_error("ROLLBACK command does not require any arguments.");
+      }
+      return std::make_unique<RollbackCommand>();
+    }
+    return nullptr;
+  }
+
+  void Execute(Context& context) const override {
+    if (!context.tx) {
+      throw std::runtime_error("No transaction in progress. Use BEGIN first.");
+    }
+    context.tx->Rollback();
+    std::cout << context.tx->GetId() << std::endl;
+    context.tx.reset();
+  }
+};
+
 class UpsertCommand : public Command {
 public:
   constexpr static const char* kName = "UPSERT";
@@ -267,6 +292,7 @@ void RegisterCommands(CommandManager& manager) {
     .Add(DropTableCommand::kName, DropTableCommand::TryParse, DropTableCommand::kHints)
     .Add(BeginCommand::kName, BeginCommand::TryParse, BeginCommand::kHints)
     .Add(CommitCommand::kName, CommitCommand::TryParse, CommitCommand::kHints)
+    .Add(RollbackCommand::kName, RollbackCommand::TryParse, RollbackCommand::kHints)
     .Add(UpsertCommand::kName, UpsertCommand::TryParse, UpsertCommand::kHints)
     .Add(LookupCommand::kName, LookupCommand::TryParse, LookupCommand::kHints)
     .Add(DeleteCommand::kName, DeleteCommand::TryParse, DeleteCommand::kHints)


### PR DESCRIPTION
## Summary
The CLI supported `BEGIN` and `COMMIT` but had no way to abort a transaction. This was an inconsistency: `BeginCommand`'s own error message already told users to *"Use COMMIT or ROLLBACK first"*, and the client library + server fully implement transaction rollback (`client::database::Transaction::Rollback`). Only the CLI command was missing.

## Changes
- **New `RollbackCommand`** in `src/cli/command/command.cpp`, mirroring `CommitCommand`:
  - requires an active transaction (otherwise `"No transaction in progress. Use BEGIN first."`)
  - takes no arguments
  - calls `context.tx->Rollback()`, prints the tx id, and clears `context.tx`
- **Registered** in `RegisterCommands`, so REPL autocompletion and hints also pick up `ROLLBACK`.

## Testing
- `structuredb-cli` builds clean; full build is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)