### PR TITLE
test(integration): Python integration-test framework wired into ctest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,3 +21,4 @@ add_subdirectory(src/cli)
 add_subdirectory(src/sdb_viewer)
 
 add_subdirectory(tests/server)
+add_subdirectory(tests/integration)

--- a/tests/integration/.gitignore
+++ b/tests/integration/.gitignore
@@ -1,0 +1,8 @@
+# Generated protobuf stubs
+.generated/
+# Local virtualenv created by run_tests.py / ctest
+.venv/
+# pytest / python caches
+.pytest_cache/
+__pycache__/
+*.pyc

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -1,0 +1,30 @@
+# Python integration-test suite, registered with ctest.
+#
+# The test bootstraps its own virtualenv (run_tests.py) so the only host
+# requirement is a Python 3 interpreter. It drives the freshly-built
+# structuredb-server binary over gRPC.
+
+option(STRUCTUREDB_INTEGRATION_TESTS "Enable the Python integration test suite" ON)
+
+if(STRUCTUREDB_INTEGRATION_TESTS)
+  find_package(Python3 COMPONENTS Interpreter)
+
+  if(Python3_Interpreter_FOUND)
+    add_test(
+      NAME integration
+      COMMAND
+        ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/run_tests.py
+        --server-binary $<TARGET_FILE:structuredb-server>
+        --venv ${CMAKE_CURRENT_BINARY_DIR}/.venv
+        -- -v
+      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    )
+    # The suite spawns servers and waits on background jobs/replication.
+    set_tests_properties(integration PROPERTIES
+      LABELS "integration"
+      TIMEOUT 600
+    )
+  else()
+    message(WARNING "Python3 not found; integration test suite disabled")
+  endif()
+endif()

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -1,0 +1,93 @@
+# StructureDB integration tests
+
+Black-box integration tests written in Python. They start real
+`structuredb-server` processes and drive them over gRPC, exercising tables,
+transaction isolation and replication end-to-end.
+
+## Running
+
+Via ctest (recommended — bootstraps its own virtualenv, builds nothing else):
+
+```bash
+make build                     # ensure structuredb-server is built
+cd build/Debug && ctest -R integration --output-on-failure
+```
+
+Directly, against an already-built binary:
+
+```bash
+cd tests/integration
+python3 run_tests.py --server-binary ../../build/Debug/src/server/structuredb-server
+# forward args to pytest after `--`:
+python3 run_tests.py --server-binary <bin> -- -k replication -v
+```
+
+`run_tests.py` creates `.venv/`, installs `requirements.txt`, generates the
+Python gRPC stubs from `proto/*.proto` and runs pytest. Everything generated is
+gitignored.
+
+## Layout
+
+```
+tests/integration/
+  sdb_testkit/        # the framework
+    config.py         # ServerConfig -> config.yaml
+    server.py         # ServerProcess: spawn / ready-wait / restart / teardown
+    client.py         # SdbClient + Transaction (gRPC wrapper, tx threading)
+    cluster.py        # ReplicationCluster: leader + N followers
+    proto_gen.py      # compile & import the .proto stubs on demand
+    ports.py, waiting.py
+  conftest.py         # pytest fixtures
+  tests/              # scenarios: test_tables / test_transactions / test_replication
+  run_tests.py        # ctest entry point (venv + deps + pytest)
+```
+
+## Fixtures
+
+| Fixture          | Gives you                                                    |
+|------------------|--------------------------------------------------------------|
+| `server`         | a running single-node `ServerProcess` (auto torn down)       |
+| `client`         | an `SdbClient` connected to `server`                         |
+| `server_config`  | the `ServerConfig` for `server` (override to tweak settings) |
+| `make_cluster`   | factory: `make_cluster(followers=1)` -> started cluster      |
+| `unique_table`   | callable returning collision-free table names               |
+| `workdir`        | per-test temp dir (configs, data, `server.log` live here)    |
+
+## Writing a test
+
+```python
+def test_roundtrip(client, unique_table):
+    t = unique_table()
+    client.create_table(t)
+    client.upsert(t, "k", "v")
+    assert client.get(t, "k") == "v"
+
+
+def test_isolation(server):
+    from sdb_testkit import SdbClient
+    with SdbClient(server.target) as writer, SdbClient(server.target) as reader:
+        writer.create_table("t")
+        tx = writer.begin()
+        writer.upsert("t", "k", "pending", tx=tx)
+        assert reader.get("t", "k") is None   # not visible before commit
+        writer.commit(tx)
+        assert reader.get("t", "k") == "pending"
+
+
+@pytest.mark.replication
+def test_replicates(make_cluster):
+    cluster = make_cluster(followers=1)
+    cluster.leader_client.create_table("t")
+    cluster.leader_client.upsert("t", "k", "v")
+    cluster.follower_client().wait_for_value("t", "k", "v")  # async; polled
+```
+
+Replication is asynchronous, so reads on a follower are polled via
+`client.wait_for_value(...)` or `sdb_testkit.wait_until(...)` rather than read
+once.
+
+## Requirements
+
+A Python 3 interpreter on the host. All Python packages (`grpcio`,
+`grpcio-tools`, `pytest`, `PyYAML`) are installed into the local venv by
+`run_tests.py`; nothing is installed system-wide.

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -57,29 +57,29 @@ tests/integration/
 
 ```python
 def test_roundtrip(client, unique_table):
-    t = unique_table()
-    client.create_table(t)
-    client.upsert(t, "k", "v")
-    assert client.get(t, "k") == "v"
+    users = unique_table("users")
+    client.create_table(users)
+    client.upsert(users, "alice", "engineer")
+    assert client.get(users, "alice") == "engineer"
 
 
 def test_isolation(server):
     from sdb_testkit import SdbClient
     with SdbClient(server.target) as writer, SdbClient(server.target) as reader:
-        writer.create_table("t")
-        tx = writer.begin()
-        writer.upsert("t", "k", "pending", tx=tx)
-        assert reader.get("t", "k") is None   # not visible before commit
-        writer.commit(tx)
-        assert reader.get("t", "k") == "pending"
+        writer.create_table("accounts")
+        transaction = writer.begin()
+        writer.upsert("accounts", "alice", "100", tx=transaction)
+        assert reader.get("accounts", "alice") is None   # not visible before commit
+        writer.commit(transaction)
+        assert reader.get("accounts", "alice") == "100"
 
 
 @pytest.mark.replication
 def test_replicates(make_cluster):
     cluster = make_cluster(followers=1)
-    cluster.leader_client.create_table("t")
-    cluster.leader_client.upsert("t", "k", "v")
-    cluster.follower_client().wait_for_value("t", "k", "v")  # async; polled
+    cluster.leader_client.create_table("accounts")
+    cluster.leader_client.upsert("accounts", "alice", "100")
+    cluster.follower_client().wait_for_value("accounts", "alice", "100")  # async; polled
 ```
 
 Replication is asynchronous, so reads on a follower are polled via

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,96 @@
+"""Pytest fixtures for StructureDB integration tests.
+
+Make the ``sdb_testkit`` package importable regardless of where pytest is
+invoked from, then expose fixtures that hand tests a ready server + client, and
+a factory for replication clusters.
+"""
+
+from __future__ import annotations
+
+import sys
+import uuid
+from pathlib import Path
+from typing import Callable, Iterator
+
+import pytest
+
+_HERE = Path(__file__).resolve().parent
+if str(_HERE) not in sys.path:
+    sys.path.insert(0, str(_HERE))
+
+from sdb_testkit import ReplicationCluster, SdbClient, ServerConfig, ServerProcess  # noqa: E402
+from sdb_testkit.ports import free_port  # noqa: E402
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _generate_proto_stubs() -> None:
+    """Compile the .proto files once per session before any client is built."""
+    from sdb_testkit import proto_gen
+
+    proto_gen.load()
+
+
+@pytest.fixture
+def workdir(tmp_path: Path) -> Path:
+    """A clean per-test working directory (configs, data, logs live here)."""
+    return tmp_path
+
+
+@pytest.fixture
+def server_config(workdir: Path) -> ServerConfig:
+    """Default single-node leader config on a free port."""
+    return ServerConfig(root=str(workdir / "data"), port=free_port())
+
+
+@pytest.fixture
+def server(server_config: ServerConfig, workdir: Path) -> Iterator[ServerProcess]:
+    """A running single-node server, torn down at test end."""
+    proc = ServerProcess(server_config, workdir)
+    proc.start()
+    try:
+        yield proc
+    finally:
+        proc.stop()
+
+
+@pytest.fixture
+def client(server: ServerProcess) -> Iterator[SdbClient]:
+    """A connected client to the single-node ``server`` fixture."""
+    cli = SdbClient(server.target)
+    try:
+        yield cli
+    finally:
+        cli.close()
+
+
+@pytest.fixture
+def unique_table() -> Callable[[], str]:
+    """Return a generator of collision-free table names."""
+
+    def _make(prefix: str = "t") -> str:
+        return f"{prefix}_{uuid.uuid4().hex[:8]}"
+
+    return _make
+
+
+@pytest.fixture
+def make_cluster(workdir: Path) -> Iterator[Callable[..., ReplicationCluster]]:
+    """Factory fixture: ``make_cluster(followers=1)`` -> started cluster.
+
+    All clusters created during a test are stopped at teardown.
+    """
+    created: list[ReplicationCluster] = []
+
+    def _make(followers: int = 1) -> ReplicationCluster:
+        cluster = ReplicationCluster(
+            workdir / f"cluster{len(created)}", followers=followers
+        )
+        cluster.start()
+        created.append(cluster)
+        return cluster
+
+    try:
+        yield _make
+    finally:
+        for cluster in created:
+            cluster.stop()

--- a/tests/integration/pytest.ini
+++ b/tests/integration/pytest.ini
@@ -1,0 +1,9 @@
+[pytest]
+testpaths = tests
+python_files = test_*.py
+python_classes = Test*
+python_functions = test_*
+addopts = -ra
+markers =
+    replication: scenarios that spin up a leader + follower cluster
+    slow: scenarios that wait on background jobs (flush/compaction/replication)

--- a/tests/integration/requirements.txt
+++ b/tests/integration/requirements.txt
@@ -1,0 +1,7 @@
+# Python integration-test framework dependencies.
+# Pinned loosely; CMake/run_tests.py installs these into a local venv.
+grpcio>=1.60,<2
+grpcio-tools>=1.60,<2
+protobuf>=4.25
+pytest>=7.4
+PyYAML>=6.0

--- a/tests/integration/run_tests.py
+++ b/tests/integration/run_tests.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""ctest entry point for the Python integration suite.
+
+Creates (and caches) a local virtualenv, installs the pinned requirements into
+it, points the suite at the built server binary and runs pytest. Designed to be
+invoked by CMake/ctest, but also usable by hand:
+
+    python3 run_tests.py --server-binary path/to/structuredb-server -- -k replication
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+import subprocess
+import sys
+import venv
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+REQUIREMENTS = HERE / "requirements.txt"
+
+
+def _venv_python(venv_dir: Path) -> Path:
+    if os.name == "nt":  # pragma: no cover - posix CI
+        return venv_dir / "Scripts" / "python.exe"
+    return venv_dir / "bin" / "python"
+
+
+def ensure_venv(venv_dir: Path) -> Path:
+    python = _venv_python(venv_dir)
+    if not python.exists():
+        print(f"[integration] creating venv at {venv_dir}", flush=True)
+        venv.EnvBuilder(with_pip=True).create(venv_dir)
+    return python
+
+
+def ensure_deps(python: Path, venv_dir: Path) -> None:
+    """Install requirements only when they change (hash marker)."""
+    digest = hashlib.sha256(REQUIREMENTS.read_bytes()).hexdigest()
+    marker = venv_dir / ".deps.sha256"
+    if marker.exists() and marker.read_text().strip() == digest:
+        return
+    print("[integration] installing python dependencies", flush=True)
+    subprocess.check_call(
+        [str(python), "-m", "pip", "install", "-q", "--disable-pip-version-check",
+         "--upgrade", "pip"]
+    )
+    subprocess.check_call(
+        [str(python), "-m", "pip", "install", "-q", "--disable-pip-version-check",
+         "-r", str(REQUIREMENTS)]
+    )
+    marker.write_text(digest)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--server-binary", required=True,
+                        help="path to the built structuredb-server")
+    parser.add_argument("--venv", default=str(HERE / ".venv"),
+                        help="virtualenv location (default: tests/integration/.venv)")
+    parser.add_argument("pytest_args", nargs="*",
+                        help="extra args forwarded to pytest (after --)")
+    args = parser.parse_args()
+
+    server_binary = Path(args.server_binary).resolve()
+    if not server_binary.is_file():
+        print(f"[integration] server binary not found: {server_binary}", file=sys.stderr)
+        return 2
+
+    venv_dir = Path(args.venv).resolve()
+    python = ensure_venv(venv_dir)
+    ensure_deps(python, venv_dir)
+
+    env = os.environ.copy()
+    env["STRUCTUREDB_SERVER_BIN"] = str(server_binary)
+    env.setdefault("STRUCTUREDB_PROTO_DIR", str((HERE / ".." / ".." / "proto").resolve()))
+
+    cmd = [str(python), "-m", "pytest", str(HERE / "tests")]
+    cmd += args.pytest_args
+    print(f"[integration] running: {' '.join(cmd)}", flush=True)
+    return subprocess.call(cmd, cwd=str(HERE), env=env)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/integration/sdb_testkit/__init__.py
+++ b/tests/integration/sdb_testkit/__init__.py
@@ -1,0 +1,28 @@
+"""sdb_testkit — a small framework for StructureDB integration tests.
+
+It spins up real ``structuredb-server`` processes, talks to them over gRPC and
+gives tests high-level helpers for tables, transactions and replication.
+
+The public surface is intentionally tiny:
+
+    from sdb_testkit import SdbClient, ServerConfig, ServerProcess, ReplicationCluster
+
+Most tests never touch these directly — they use the pytest fixtures in
+``conftest.py`` (``client``, ``server``, ``make_cluster`` …).
+"""
+
+from .config import ServerConfig
+from .server import ServerProcess
+from .client import SdbClient, Record, Transaction
+from .cluster import ReplicationCluster
+from .waiting import wait_until
+
+__all__ = [
+    "ServerConfig",
+    "ServerProcess",
+    "SdbClient",
+    "Record",
+    "Transaction",
+    "ReplicationCluster",
+    "wait_until",
+]

--- a/tests/integration/sdb_testkit/client.py
+++ b/tests/integration/sdb_testkit/client.py
@@ -1,0 +1,188 @@
+"""A thin, test-friendly gRPC client for StructureDB.
+
+Wraps the generated ``Tables`` / ``Transactions`` stubs and exposes ergonomic
+methods. The server models a transaction as an opaque ``tx`` token threaded
+through every request; ``SdbClient`` lets you pass ``tx=...`` explicitly, or use
+the :class:`Transaction` helper / :meth:`SdbClient.transaction` context manager
+which thread it for you.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Optional, Tuple
+
+import grpc
+
+from . import proto_gen
+from .waiting import wait_until
+
+
+@dataclass(frozen=True)
+class Record:
+    key: str
+    value: str
+
+
+class SdbClient:
+    """Connect to a server target (``host:port``) and run table/tx operations."""
+
+    def __init__(self, target: str, connect_timeout: float = 10.0) -> None:
+        self._pb = proto_gen.load()
+        self.target = target
+        self._channel = grpc.insecure_channel(target)
+        try:
+            grpc.channel_ready_future(self._channel).result(timeout=connect_timeout)
+        except grpc.FutureTimeoutError as exc:  # pragma: no cover - startup race
+            raise TimeoutError(f"could not connect to {target}") from exc
+        self._tables = self._pb.table_grpc.TablesStub(self._channel)
+        self._tx = self._pb.tx_grpc.TransactionsStub(self._channel)
+
+    def close(self) -> None:
+        self._channel.close()
+
+    def __enter__(self) -> "SdbClient":
+        return self
+
+    def __exit__(self, *exc) -> None:
+        self.close()
+
+    # -- DDL ---------------------------------------------------------------
+
+    def create_table(self, name: str, tx: Optional[str] = None) -> str:
+        req = self._pb.table_pb2.CreateTableRequest(name=name)
+        if tx is not None:
+            req.tx = tx
+        return self._tables.CreateTable(req).tx
+
+    def drop_table(self, name: str, tx: Optional[str] = None) -> str:
+        req = self._pb.table_pb2.DropTableRequest(name=name)
+        if tx is not None:
+            req.tx = tx
+        return self._tables.DropTable(req).tx
+
+    def compact_table(self, table: str, tx: Optional[str] = None) -> None:
+        req = self._pb.table_pb2.CompactTableRequest(table=table)
+        if tx is not None:
+            req.tx = tx
+        self._tables.CompactTable(req)
+
+    # -- DML ---------------------------------------------------------------
+
+    def upsert(self, table: str, key: str, value: str, tx: Optional[str] = None) -> str:
+        req = self._pb.table_pb2.UpsertTableRequest(table=table, key=key, value=value)
+        if tx is not None:
+            req.tx = tx
+        return self._tables.Upsert(req).tx
+
+    def lookup(
+        self, table: str, key: str, tx: Optional[str] = None
+    ) -> Tuple[Optional[str], str]:
+        """Return ``(value_or_None, tx)``. Missing keys yield ``None``."""
+        req = self._pb.table_pb2.LookupTableRequest(table=table, key=key)
+        if tx is not None:
+            req.tx = tx
+        resp = self._tables.Lookup(req)
+        value = resp.value if resp.HasField("value") else None
+        return value, resp.tx
+
+    def get(self, table: str, key: str, tx: Optional[str] = None) -> Optional[str]:
+        """Convenience: just the value (or None), dropping the tx token."""
+        return self.lookup(table, key, tx)[0]
+
+    def delete(self, table: str, key: str, tx: Optional[str] = None) -> str:
+        req = self._pb.table_pb2.DeleteTableRequest(table=table, key=key)
+        if tx is not None:
+            req.tx = tx
+        return self._tables.Delete(req).tx
+
+    def scan(
+        self,
+        table: str,
+        lower_bound: Optional[str] = None,
+        upper_bound: Optional[str] = None,
+        tx: Optional[str] = None,
+    ) -> Tuple[List[Record], str]:
+        req = self._pb.table_pb2.ScanTableRequest(table=table)
+        if lower_bound is not None:
+            req.lower_bound = lower_bound
+        if upper_bound is not None:
+            req.upper_bound = upper_bound
+        if tx is not None:
+            req.tx = tx
+        resp = self._tables.Scan(req)
+        records = [Record(r.key, r.value) for r in resp.records]
+        return records, resp.tx
+
+    # -- transactions ------------------------------------------------------
+
+    def begin(self) -> str:
+        return self._tx.Begin(self._pb.tx_pb2.BeginRequest()).tx
+
+    def commit(self, tx: str) -> None:
+        self._tx.Commit(self._pb.tx_pb2.CommitRequest(tx=tx))
+
+    def transaction(self) -> "Transaction":
+        """Open a transaction; commits on clean exit, abandons on exception."""
+        return Transaction(self, self.begin())
+
+    # -- replication / async helpers --------------------------------------
+
+    def wait_for_value(
+        self, table: str, key: str, expected: str, *, timeout: float = 10.0
+    ) -> None:
+        """Poll ``lookup`` until ``key`` reads back ``expected`` (e.g. on a follower)."""
+        wait_until(
+            lambda: self.get(table, key) == expected,
+            timeout=timeout,
+            message=f"{table}/{key} did not become {expected!r} on {self.target}",
+        )
+
+
+class Transaction:
+    """Operations bound to a single ``tx`` token.
+
+    Used as a context manager::
+
+        with client.transaction() as tx:
+            tx.upsert("t", "k", "v")
+        # committed here
+    """
+
+    def __init__(self, client: SdbClient, tx: str) -> None:
+        self._client = client
+        self.id = tx
+        self._done = False
+
+    def create_table(self, name: str) -> None:
+        self._client.create_table(name, tx=self.id)
+
+    def drop_table(self, name: str) -> None:
+        self._client.drop_table(name, tx=self.id)
+
+    def upsert(self, table: str, key: str, value: str) -> None:
+        self._client.upsert(table, key, value, tx=self.id)
+
+    def lookup(self, table: str, key: str) -> Optional[str]:
+        return self._client.lookup(table, key, tx=self.id)[0]
+
+    def delete(self, table: str, key: str) -> None:
+        self._client.delete(table, key, tx=self.id)
+
+    def scan(
+        self, table: str, lower_bound: Optional[str] = None, upper_bound: Optional[str] = None
+    ) -> List[Record]:
+        return self._client.scan(table, lower_bound, upper_bound, tx=self.id)[0]
+
+    def commit(self) -> None:
+        if not self._done:
+            self._client.commit(self.id)
+            self._done = True
+
+    def __enter__(self) -> "Transaction":
+        return self
+
+    def __exit__(self, exc_type, *_) -> None:
+        if exc_type is None:
+            self.commit()
+        # On error we simply drop the token; the server discards uncommitted work.

--- a/tests/integration/sdb_testkit/cluster.py
+++ b/tests/integration/sdb_testkit/cluster.py
@@ -1,0 +1,100 @@
+"""A leader + N follower cluster for replication scenarios."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List, Optional
+
+from .client import SdbClient
+from .config import ServerConfig
+from .ports import free_port
+from .server import ServerProcess
+
+
+class ReplicationCluster:
+    """Spin up one leader and one or more followers wired to it.
+
+    Example::
+
+        with ReplicationCluster(workdir, followers=1) as cluster:
+            cluster.leader_client.create_table("t")
+            cluster.leader_client.upsert("t", "k", "v")
+            cluster.follower_client().wait_for_value("t", "k", "v")
+    """
+
+    def __init__(
+        self,
+        workdir: str | Path,
+        followers: int = 1,
+        binary: Optional[str] = None,
+        poll_interval_ms: int = 50,
+    ) -> None:
+        self.workdir = Path(workdir)
+        self._binary = binary
+        self._poll = poll_interval_ms
+        self._num_followers = followers
+
+        self.leader: Optional[ServerProcess] = None
+        self.followers: List[ServerProcess] = []
+        self._clients: List[SdbClient] = []
+
+    # -- lifecycle ---------------------------------------------------------
+
+    def start(self) -> "ReplicationCluster":
+        leader_port = free_port()
+        leader_cfg = ServerConfig(
+            root=str(self.workdir / "leader" / "data"),
+            port=leader_port,
+            role="leader",
+            poll_interval_ms=self._poll,
+        )
+        self.leader = ServerProcess(
+            leader_cfg, self.workdir / "leader", binary=self._binary
+        ).start()
+
+        for i in range(self._num_followers):
+            follower_cfg = ServerConfig(
+                root=str(self.workdir / f"follower{i}" / "data"),
+                port=free_port(),
+                role="follower",
+                leader_address=leader_cfg.target,
+                poll_interval_ms=self._poll,
+            )
+            follower = ServerProcess(
+                follower_cfg, self.workdir / f"follower{i}", binary=self._binary
+            ).start()
+            self.followers.append(follower)
+        return self
+
+    def stop(self) -> None:
+        for client in self._clients:
+            client.close()
+        self._clients.clear()
+        for follower in self.followers:
+            follower.stop()
+        self.followers.clear()
+        if self.leader is not None:
+            self.leader.stop()
+            self.leader = None
+
+    # -- clients -----------------------------------------------------------
+
+    def _track(self, client: SdbClient) -> SdbClient:
+        self._clients.append(client)
+        return client
+
+    @property
+    def leader_client(self) -> SdbClient:
+        assert self.leader is not None, "cluster not started"
+        return self._track(SdbClient(self.leader.target))
+
+    def follower_client(self, index: int = 0) -> SdbClient:
+        return self._track(SdbClient(self.followers[index].target))
+
+    # -- context manager ---------------------------------------------------
+
+    def __enter__(self) -> "ReplicationCluster":
+        return self.start()
+
+    def __exit__(self, *exc) -> None:
+        self.stop()

--- a/tests/integration/sdb_testkit/config.py
+++ b/tests/integration/sdb_testkit/config.py
@@ -1,0 +1,82 @@
+"""Render a ``config.yaml`` for a server instance under test.
+
+Mirrors ``src/server/cfg/config.hpp``. Defaults are tuned for fast tests:
+short flush / compaction / wal-clean intervals so background jobs and
+replication converge quickly.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+import yaml
+
+
+@dataclass
+class ServerConfig:
+    root: str
+    port: int
+
+    # replication
+    role: str = "leader"  # "leader" | "follower"
+    leader_address: Optional[str] = None
+    poll_interval_ms: int = 50
+
+    # background-job intervals (ms) — short so tests don't wait minutes
+    flush_interval_ms: int = 200
+    compaction_interval_ms: int = 1000
+    wal_clean_interval_ms: int = 1000
+
+    # lsm — small mem table so flushes / SSTables happen with little data
+    max_records_in_mem_table: int = 128
+    max_ro_mem_tables: int = 1
+    page_size: int = 4096
+    page_cache_capacity: int = 1024
+
+    # logging
+    log_level: str = "info"
+    log_console: bool = True
+    log_file: Optional[str] = None
+
+    extra: dict = field(default_factory=dict)
+
+    def to_dict(self) -> dict:
+        logger: dict = {"level": self.log_level, "console": self.log_console}
+        if self.log_file is not None:
+            logger["file"] = self.log_file
+
+        replication: dict = {"role": self.role, "poll_interval": self.poll_interval_ms}
+        if self.role == "follower":
+            if not self.leader_address:
+                raise ValueError("follower config requires leader_address")
+            replication["leader_address"] = self.leader_address
+
+        cfg = {
+            "root": self.root,
+            "port": self.port,
+            "logger": logger,
+            "compaction": {"interval": self.compaction_interval_ms},
+            "flush": {"interval": self.flush_interval_ms},
+            "wal": {"clean": {"interval": self.wal_clean_interval_ms}},
+            "lsm": {
+                "max_records_in_mem_table": self.max_records_in_mem_table,
+                "max_ro_mem_tables": self.max_ro_mem_tables,
+                "page_size": self.page_size,
+                "page_cache_capacity": self.page_cache_capacity,
+            },
+            "replication": replication,
+        }
+        cfg.update(self.extra)
+        return cfg
+
+    def write(self, path: str | Path) -> Path:
+        path = Path(path)
+        path.write_text(yaml.safe_dump(self.to_dict(), sort_keys=False))
+        return path
+
+    @property
+    def target(self) -> str:
+        """gRPC target (host:port) clients connect to."""
+        return f"127.0.0.1:{self.port}"

--- a/tests/integration/sdb_testkit/ports.py
+++ b/tests/integration/sdb_testkit/ports.py
@@ -1,0 +1,29 @@
+"""Free-port allocation for ephemeral server instances."""
+
+from __future__ import annotations
+
+import socket
+
+
+def free_port() -> int:
+    """Return a currently-free TCP port on localhost.
+
+    There is an inherent race between releasing the port here and the server
+    binding it, but for local test processes started immediately afterwards it
+    is reliable in practice.
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def port_is_open(host: str, port: int, timeout: float = 0.25) -> bool:
+    """Return True if a TCP connection to ``host:port`` succeeds."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.settimeout(timeout)
+        try:
+            sock.connect((host, port))
+            return True
+        except OSError:
+            return False

--- a/tests/integration/sdb_testkit/proto_gen.py
+++ b/tests/integration/sdb_testkit/proto_gen.py
@@ -1,0 +1,104 @@
+"""Generate (and import) Python gRPC stubs from the project's .proto files.
+
+The C++ build owns ``proto/*.proto``; rather than vendoring a second copy of
+generated Python, we compile the stubs on demand into a gitignored directory
+and put it on ``sys.path``. Regeneration only happens when a ``.proto`` is newer
+than the last successful generation, so repeated test runs are cheap.
+
+Override locations with env vars when running outside the repo layout:
+
+    STRUCTUREDB_PROTO_DIR   directory containing the .proto files
+    STRUCTUREDB_PROTO_OUT   directory to write generated *_pb2.py into
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import types
+from pathlib import Path
+
+# tests/integration/sdb_testkit/proto_gen.py -> repo root is three parents up.
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_INTEGRATION_DIR = Path(__file__).resolve().parents[1]
+
+
+def _proto_dir() -> Path:
+    env = os.environ.get("STRUCTUREDB_PROTO_DIR")
+    return Path(env) if env else _REPO_ROOT / "proto"
+
+
+def _out_dir() -> Path:
+    env = os.environ.get("STRUCTUREDB_PROTO_OUT")
+    return Path(env) if env else _INTEGRATION_DIR / ".generated"
+
+
+def _needs_regen(protos: list[Path], marker: Path) -> bool:
+    if not marker.exists():
+        return True
+    newest_proto = max(p.stat().st_mtime for p in protos)
+    return marker.stat().st_mtime < newest_proto
+
+
+def _generate(proto_dir: Path, out_dir: Path, protos: list[Path]) -> None:
+    from grpc_tools import protoc  # imported lazily so the dep is only needed here
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    args = [
+        "grpc_tools.protoc",
+        f"-I{proto_dir}",
+        f"--python_out={out_dir}",
+        f"--grpc_python_out={out_dir}",
+        *[str(p) for p in protos],
+    ]
+    rc = protoc.main(args)
+    if rc != 0:
+        raise RuntimeError(f"protoc failed (exit {rc}) for {[p.name for p in protos]}")
+    (out_dir / ".gen_ok").touch()
+
+
+_loaded: types.SimpleNamespace | None = None
+
+
+def load() -> types.SimpleNamespace:
+    """Ensure stubs exist, import them, and return a namespace of the modules.
+
+    Returns a ``SimpleNamespace`` with: ``table_pb2``, ``table_grpc``,
+    ``tx_pb2``, ``tx_grpc``, ``repl_pb2``, ``repl_grpc``.
+    """
+    global _loaded
+    if _loaded is not None:
+        return _loaded
+
+    proto_dir = _proto_dir()
+    out_dir = _out_dir()
+    protos = sorted(proto_dir.glob("*.proto"))
+    if not protos:
+        raise FileNotFoundError(f"no .proto files found under {proto_dir}")
+
+    if _needs_regen(protos, out_dir / ".gen_ok"):
+        _generate(proto_dir, out_dir, protos)
+
+    # Generated *_pb2_grpc.py use top-level imports (``import table_service_pb2``),
+    # so the output directory itself must be importable as a search path.
+    if str(out_dir) not in sys.path:
+        sys.path.insert(0, str(out_dir))
+
+    import importlib
+
+    table_pb2 = importlib.import_module("table_service_pb2")
+    table_grpc = importlib.import_module("table_service_pb2_grpc")
+    tx_pb2 = importlib.import_module("transaction_service_pb2")
+    tx_grpc = importlib.import_module("transaction_service_pb2_grpc")
+    repl_pb2 = importlib.import_module("replication_service_pb2")
+    repl_grpc = importlib.import_module("replication_service_pb2_grpc")
+
+    _loaded = types.SimpleNamespace(
+        table_pb2=table_pb2,
+        table_grpc=table_grpc,
+        tx_pb2=tx_pb2,
+        tx_grpc=tx_grpc,
+        repl_pb2=repl_pb2,
+        repl_grpc=repl_grpc,
+    )
+    return _loaded

--- a/tests/integration/sdb_testkit/server.py
+++ b/tests/integration/sdb_testkit/server.py
@@ -1,0 +1,134 @@
+"""Manage the lifecycle of a single ``structuredb-server`` process."""
+
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import time
+from pathlib import Path
+from typing import Optional
+
+from .config import ServerConfig
+from .ports import port_is_open
+
+
+def _server_binary() -> str:
+    binary = os.environ.get("STRUCTUREDB_SERVER_BIN")
+    if not binary:
+        raise RuntimeError(
+            "STRUCTUREDB_SERVER_BIN is not set. Run the suite via ctest, or "
+            "export it to the built server path "
+            "(e.g. build/Debug/src/server/structuredb-server)."
+        )
+    if not Path(binary).is_file():
+        raise FileNotFoundError(f"server binary not found: {binary}")
+    return binary
+
+
+class ServerProcess:
+    """A running server instance: writes its config, spawns it, waits for ready.
+
+    Use as a context manager or call ``start()`` / ``stop()`` explicitly.
+    Stdout/stderr are captured to ``<workdir>/server.log`` and the tail is
+    surfaced on a failed startup to make debugging easy.
+    """
+
+    def __init__(
+        self,
+        config: ServerConfig,
+        workdir: str | Path,
+        binary: Optional[str] = None,
+        startup_timeout: float = 20.0,
+    ) -> None:
+        self.config = config
+        self.workdir = Path(workdir)
+        self.binary = binary or _server_binary()
+        self.startup_timeout = startup_timeout
+        self._proc: Optional[subprocess.Popen] = None
+        self._log_path = self.workdir / "server.log"
+        self._log_file = None
+
+    # -- lifecycle ---------------------------------------------------------
+
+    def start(self) -> "ServerProcess":
+        self.workdir.mkdir(parents=True, exist_ok=True)
+        # create_directory() in the server is non-recursive, so make sure the
+        # data root's parent exists; creating root itself is harmless.
+        Path(self.config.root).mkdir(parents=True, exist_ok=True)
+
+        config_path = self.config.write(self.workdir / "config.yaml")
+        self._log_file = open(self._log_path, "wb")
+        self._proc = subprocess.Popen(
+            [self.binary, f"--config={config_path}"],
+            stdout=self._log_file,
+            stderr=subprocess.STDOUT,
+            cwd=str(self.workdir),
+        )
+        self._wait_until_ready()
+        return self
+
+    def _wait_until_ready(self) -> None:
+        deadline = time.monotonic() + self.startup_timeout
+        host, port = "127.0.0.1", self.config.port
+        while time.monotonic() < deadline:
+            if self._proc.poll() is not None:
+                raise RuntimeError(
+                    f"server exited early (code {self._proc.returncode}) "
+                    f"during startup:\n{self.log_tail()}"
+                )
+            if port_is_open(host, port):
+                return
+            time.sleep(0.05)
+        self.stop()
+        raise TimeoutError(
+            f"server did not open {host}:{port} within {self.startup_timeout}s:\n"
+            f"{self.log_tail()}"
+        )
+
+    def stop(self, timeout: float = 10.0) -> None:
+        proc = self._proc
+        if proc is not None and proc.poll() is None:
+            proc.send_signal(signal.SIGTERM)
+            try:
+                proc.wait(timeout=timeout)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait(timeout=timeout)
+        self._proc = None
+        if self._log_file is not None:
+            self._log_file.close()
+            self._log_file = None
+
+    def restart(self) -> "ServerProcess":
+        """Stop and start again with the same config/data dir (recovery path)."""
+        self.stop()
+        return self.start()
+
+    # -- introspection -----------------------------------------------------
+
+    @property
+    def target(self) -> str:
+        return self.config.target
+
+    @property
+    def pid(self) -> Optional[int]:
+        return self._proc.pid if self._proc else None
+
+    def is_running(self) -> bool:
+        return self._proc is not None and self._proc.poll() is None
+
+    def log_tail(self, lines: int = 60) -> str:
+        try:
+            content = self._log_path.read_text(errors="replace").splitlines()
+        except OSError:
+            return "<no server log>"
+        return "\n".join(content[-lines:])
+
+    # -- context manager ---------------------------------------------------
+
+    def __enter__(self) -> "ServerProcess":
+        return self.start()
+
+    def __exit__(self, *exc) -> None:
+        self.stop()

--- a/tests/integration/sdb_testkit/waiting.py
+++ b/tests/integration/sdb_testkit/waiting.py
@@ -1,0 +1,42 @@
+"""Polling helpers for asynchronous behaviour (flush, compaction, replication)."""
+
+from __future__ import annotations
+
+import time
+from typing import Callable, Optional, TypeVar
+
+T = TypeVar("T")
+
+
+class TimeoutError_(AssertionError):
+    """Raised when a polled condition does not become true in time."""
+
+
+def wait_until(
+    predicate: Callable[[], T],
+    *,
+    timeout: float = 10.0,
+    interval: float = 0.1,
+    message: Optional[str] = None,
+) -> T:
+    """Poll ``predicate`` until it returns a truthy value or ``timeout`` elapses.
+
+    Returns the truthy value. Raises ``TimeoutError_`` on timeout. Exceptions
+    raised by ``predicate`` are swallowed and retried until the deadline, so it
+    is safe to poll an endpoint that is briefly unavailable.
+    """
+    deadline = time.monotonic() + timeout
+    last_exc: Optional[BaseException] = None
+    while True:
+        try:
+            value = predicate()
+            if value:
+                return value
+        except Exception as exc:  # noqa: BLE001 - retry transient failures
+            last_exc = exc
+        if time.monotonic() >= deadline:
+            detail = message or "condition not met"
+            if last_exc is not None:
+                detail += f" (last error: {last_exc!r})"
+            raise TimeoutError_(f"wait_until timed out after {timeout}s: {detail}")
+        time.sleep(interval)

--- a/tests/integration/tests/test_replication.py
+++ b/tests/integration/tests/test_replication.py
@@ -18,19 +18,19 @@ def test_write_propagates_to_follower(make_cluster):
     leader = cluster.leader_client
     follower = cluster.follower_client()
 
-    leader.create_table("t")
-    leader.upsert("t", "k", "v")
+    leader.create_table("accounts")
+    leader.upsert("accounts", "alice", "100")
 
-    follower.wait_for_value("t", "k", "v")
+    follower.wait_for_value("accounts", "alice", "100")
 
 
 def test_follower_rejects_writes(make_cluster):
     cluster = make_cluster(followers=1)
     follower = cluster.follower_client()
 
-    with pytest.raises(grpc.RpcError) as exc_info:
-        follower.upsert("any_table", "k", "v")
-    assert exc_info.value.code() == grpc.StatusCode.FAILED_PRECONDITION
+    with pytest.raises(grpc.RpcError) as rejected:
+        follower.upsert("accounts", "alice", "100")
+    assert rejected.value.code() == grpc.StatusCode.FAILED_PRECONDITION
 
 
 def test_follower_serves_reads(make_cluster):
@@ -38,13 +38,14 @@ def test_follower_serves_reads(make_cluster):
     leader = cluster.leader_client
     follower = cluster.follower_client()
 
-    leader.create_table("reads")
-    for i in range(5):
-        leader.upsert("reads", f"k{i}", f"v{i}")
+    leader.create_table("accounts")
+    balances = {f"user{number}": str(number * 100) for number in range(5)}
+    for owner, balance in balances.items():
+        leader.upsert("accounts", owner, balance)
 
-    follower.wait_for_value("reads", "k4", "v4")
-    records, _ = follower.scan("reads")
-    assert {r.key: r.value for r in records} == {f"k{i}": f"v{i}" for i in range(5)}
+    follower.wait_for_value("accounts", "user4", "400")
+    records, _ = follower.scan("accounts")
+    assert {record.key: record.value for record in records} == balances
 
 
 def test_updates_and_deletes_replicate(make_cluster):
@@ -52,18 +53,18 @@ def test_updates_and_deletes_replicate(make_cluster):
     leader = cluster.leader_client
     follower = cluster.follower_client()
 
-    leader.create_table("t")
-    leader.upsert("t", "k", "first")
-    follower.wait_for_value("t", "k", "first")
+    leader.create_table("accounts")
+    leader.upsert("accounts", "alice", "100")
+    follower.wait_for_value("accounts", "alice", "100")
 
-    leader.upsert("t", "k", "second")
-    follower.wait_for_value("t", "k", "second")
+    leader.upsert("accounts", "alice", "250")
+    follower.wait_for_value("accounts", "alice", "250")
 
-    leader.delete("t", "k")
+    leader.delete("accounts", "alice")
     from sdb_testkit import wait_until
 
     wait_until(
-        lambda: follower.get("t", "k") is None,
+        lambda: follower.get("accounts", "alice") is None,
         message="delete did not replicate to follower",
     )
 
@@ -72,8 +73,10 @@ def test_multiple_followers_converge(make_cluster):
     cluster = make_cluster(followers=2)
     leader = cluster.leader_client
 
-    leader.create_table("t")
-    leader.upsert("t", "k", "shared")
+    leader.create_table("accounts")
+    leader.upsert("accounts", "alice", "100")
 
-    for i in range(2):
-        cluster.follower_client(i).wait_for_value("t", "k", "shared")
+    for follower_index in range(2):
+        cluster.follower_client(follower_index).wait_for_value(
+            "accounts", "alice", "100"
+        )

--- a/tests/integration/tests/test_replication.py
+++ b/tests/integration/tests/test_replication.py
@@ -1,0 +1,79 @@
+"""Leader -> follower replication scenarios.
+
+These use the ``make_cluster`` fixture, which spins up a leader plus one or more
+followers wired to stream its WAL. Replication is asynchronous, so reads on the
+follower are polled with ``wait_for_value`` / ``wait_until``.
+"""
+
+from __future__ import annotations
+
+import grpc
+import pytest
+
+pytestmark = [pytest.mark.replication, pytest.mark.slow]
+
+
+def test_write_propagates_to_follower(make_cluster):
+    cluster = make_cluster(followers=1)
+    leader = cluster.leader_client
+    follower = cluster.follower_client()
+
+    leader.create_table("t")
+    leader.upsert("t", "k", "v")
+
+    follower.wait_for_value("t", "k", "v")
+
+
+def test_follower_rejects_writes(make_cluster):
+    cluster = make_cluster(followers=1)
+    follower = cluster.follower_client()
+
+    with pytest.raises(grpc.RpcError) as exc_info:
+        follower.upsert("any_table", "k", "v")
+    assert exc_info.value.code() == grpc.StatusCode.FAILED_PRECONDITION
+
+
+def test_follower_serves_reads(make_cluster):
+    cluster = make_cluster(followers=1)
+    leader = cluster.leader_client
+    follower = cluster.follower_client()
+
+    leader.create_table("reads")
+    for i in range(5):
+        leader.upsert("reads", f"k{i}", f"v{i}")
+
+    follower.wait_for_value("reads", "k4", "v4")
+    records, _ = follower.scan("reads")
+    assert {r.key: r.value for r in records} == {f"k{i}": f"v{i}" for i in range(5)}
+
+
+def test_updates_and_deletes_replicate(make_cluster):
+    cluster = make_cluster(followers=1)
+    leader = cluster.leader_client
+    follower = cluster.follower_client()
+
+    leader.create_table("t")
+    leader.upsert("t", "k", "first")
+    follower.wait_for_value("t", "k", "first")
+
+    leader.upsert("t", "k", "second")
+    follower.wait_for_value("t", "k", "second")
+
+    leader.delete("t", "k")
+    from sdb_testkit import wait_until
+
+    wait_until(
+        lambda: follower.get("t", "k") is None,
+        message="delete did not replicate to follower",
+    )
+
+
+def test_multiple_followers_converge(make_cluster):
+    cluster = make_cluster(followers=2)
+    leader = cluster.leader_client
+
+    leader.create_table("t")
+    leader.upsert("t", "k", "shared")
+
+    for i in range(2):
+        cluster.follower_client(i).wait_for_value("t", "k", "shared")

--- a/tests/integration/tests/test_tables.py
+++ b/tests/integration/tests/test_tables.py
@@ -1,0 +1,89 @@
+"""Table CRUD and scan scenarios against a single-node server."""
+
+from __future__ import annotations
+
+import pytest
+
+
+def test_create_and_roundtrip(client, unique_table):
+    table = unique_table()
+    client.create_table(table)
+
+    client.upsert(table, "key1", "value1")
+    assert client.get(table, "key1") == "value1"
+
+
+def test_lookup_missing_key_returns_none(client, unique_table):
+    table = unique_table()
+    client.create_table(table)
+
+    assert client.get(table, "absent") is None
+
+
+def test_upsert_overwrites(client, unique_table):
+    table = unique_table()
+    client.create_table(table)
+
+    client.upsert(table, "k", "first")
+    client.upsert(table, "k", "second")
+    assert client.get(table, "k") == "second"
+
+
+def test_delete_removes_key(client, unique_table):
+    table = unique_table()
+    client.create_table(table)
+
+    client.upsert(table, "k", "v")
+    assert client.get(table, "k") == "v"
+
+    client.delete(table, "k")
+    assert client.get(table, "k") is None
+
+
+def test_scan_returns_sorted_range(client, unique_table):
+    table = unique_table()
+    client.create_table(table)
+
+    for key in ["b", "d", "a", "c"]:
+        client.upsert(table, key, key.upper())
+
+    records, _ = client.scan(table)
+    keys = [r.key for r in records]
+    assert keys == sorted(keys), "scan must return keys in sorted order"
+    assert {r.key: r.value for r in records} == {
+        "a": "A",
+        "b": "B",
+        "c": "C",
+        "d": "D",
+    }
+
+
+def test_scan_bounds(client, unique_table):
+    table = unique_table()
+    client.create_table(table)
+    for key in ["a", "b", "c", "d", "e"]:
+        client.upsert(table, key, key)
+
+    records, _ = client.scan(table, lower_bound="b", upper_bound="d")
+    keys = [r.key for r in records]
+    # Lower bound inclusive; assert the window without over-constraining the
+    # upper-bound convention (kept robust across inclusive/exclusive impls).
+    assert keys[0] == "b"
+    assert "a" not in keys
+    assert "e" not in keys
+
+
+@pytest.mark.slow
+def test_data_survives_restart(server, unique_table):
+    """Writes are durable across a process restart via WAL recovery."""
+    from sdb_testkit import SdbClient
+
+    table = unique_table()
+    with SdbClient(server.target) as client:
+        client.create_table(table)
+        client.upsert(table, "durable", "yes")
+
+    server.restart()
+
+    with SdbClient(server.target) as client:
+        assert client.get(table, "durable") == "yes"

--- a/tests/integration/tests/test_tables.py
+++ b/tests/integration/tests/test_tables.py
@@ -6,71 +6,72 @@ import pytest
 
 
 def test_create_and_roundtrip(client, unique_table):
-    table = unique_table()
-    client.create_table(table)
+    users = unique_table("users")
+    client.create_table(users)
 
-    client.upsert(table, "key1", "value1")
-    assert client.get(table, "key1") == "value1"
+    client.upsert(users, "alice", "engineer")
+    assert client.get(users, "alice") == "engineer"
 
 
 def test_lookup_missing_key_returns_none(client, unique_table):
-    table = unique_table()
-    client.create_table(table)
+    users = unique_table("users")
+    client.create_table(users)
 
-    assert client.get(table, "absent") is None
+    assert client.get(users, "absent") is None
 
 
 def test_upsert_overwrites(client, unique_table):
-    table = unique_table()
-    client.create_table(table)
+    users = unique_table("users")
+    client.create_table(users)
 
-    client.upsert(table, "k", "first")
-    client.upsert(table, "k", "second")
-    assert client.get(table, "k") == "second"
+    client.upsert(users, "alice", "engineer")
+    client.upsert(users, "alice", "manager")
+    assert client.get(users, "alice") == "manager"
 
 
 def test_delete_removes_key(client, unique_table):
-    table = unique_table()
-    client.create_table(table)
+    users = unique_table("users")
+    client.create_table(users)
 
-    client.upsert(table, "k", "v")
-    assert client.get(table, "k") == "v"
+    client.upsert(users, "alice", "engineer")
+    assert client.get(users, "alice") == "engineer"
 
-    client.delete(table, "k")
-    assert client.get(table, "k") is None
+    client.delete(users, "alice")
+    assert client.get(users, "alice") is None
 
 
 def test_scan_returns_sorted_range(client, unique_table):
-    table = unique_table()
-    client.create_table(table)
+    countries = unique_table("countries")
+    client.create_table(countries)
 
-    for key in ["b", "d", "a", "c"]:
-        client.upsert(table, key, key.upper())
-
-    records, _ = client.scan(table)
-    keys = [r.key for r in records]
-    assert keys == sorted(keys), "scan must return keys in sorted order"
-    assert {r.key: r.value for r in records} == {
-        "a": "A",
-        "b": "B",
-        "c": "C",
-        "d": "D",
+    capitals = {
+        "france": "paris",
+        "germany": "berlin",
+        "italy": "rome",
+        "spain": "madrid",
     }
+    for country, capital in capitals.items():
+        client.upsert(countries, country, capital)
+
+    records, _ = client.scan(countries)
+    scanned_keys = [record.key for record in records]
+    assert scanned_keys == sorted(scanned_keys), "scan must return keys in sorted order"
+    assert {record.key: record.value for record in records} == capitals
 
 
 def test_scan_bounds(client, unique_table):
-    table = unique_table()
-    client.create_table(table)
-    for key in ["a", "b", "c", "d", "e"]:
-        client.upsert(table, key, key)
+    letters = unique_table("letters")
+    client.create_table(letters)
+    for letter in ["alpha", "bravo", "charlie", "delta", "echo"]:
+        client.upsert(letters, letter, letter.upper())
 
-    records, _ = client.scan(table, lower_bound="b", upper_bound="d")
-    keys = [r.key for r in records]
+    records, _ = client.scan(letters, lower_bound="bravo", upper_bound="delta")
+    scanned_keys = [record.key for record in records]
     # Lower bound inclusive; assert the window without over-constraining the
     # upper-bound convention (kept robust across inclusive/exclusive impls).
-    assert keys[0] == "b"
-    assert "a" not in keys
-    assert "e" not in keys
+    assert scanned_keys[0] == "bravo"
+    assert "alpha" not in scanned_keys
+    assert "echo" not in scanned_keys
 
 
 @pytest.mark.slow
@@ -78,12 +79,12 @@ def test_data_survives_restart(server, unique_table):
     """Writes are durable across a process restart via WAL recovery."""
     from sdb_testkit import SdbClient
 
-    table = unique_table()
+    accounts = unique_table("accounts")
     with SdbClient(server.target) as client:
-        client.create_table(table)
-        client.upsert(table, "durable", "yes")
+        client.create_table(accounts)
+        client.upsert(accounts, "alice", "100")
 
     server.restart()
 
     with SdbClient(server.target) as client:
-        assert client.get(table, "durable") == "yes"
+        assert client.get(accounts, "alice") == "100"

--- a/tests/integration/tests/test_transactions.py
+++ b/tests/integration/tests/test_transactions.py
@@ -1,0 +1,84 @@
+"""Transaction scenarios: read-your-writes, isolation, atomic commit.
+
+The server models a transaction as an opaque ``tx`` token threaded through
+requests. These tests exercise that surface via the high-level helpers.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+def test_read_your_own_writes(client, unique_table):
+    table = unique_table()
+    client.create_table(table)
+
+    with client.transaction() as tx:
+        tx.upsert(table, "k", "inside")
+        # The writing transaction sees its own uncommitted write.
+        assert tx.lookup(table, "k") == "inside"
+
+
+def test_uncommitted_write_isolated_from_other_reader(server, unique_table):
+    """A separate connection must not observe an in-flight transaction's write."""
+    from sdb_testkit import SdbClient
+
+    table = unique_table()
+    with SdbClient(server.target) as writer, SdbClient(server.target) as reader:
+        writer.create_table(table)
+
+        tx = writer.begin()
+        writer.upsert(table, "k", "pending", tx=tx)
+
+        # Outside the transaction the key is not yet visible.
+        assert reader.get(table, "k") is None
+
+        writer.commit(tx)
+
+        # After commit the value becomes visible to the other reader.
+        assert reader.get(table, "k") == "pending"
+
+
+def test_committed_transaction_is_visible(client, unique_table):
+    table = unique_table()
+    client.create_table(table)
+
+    with client.transaction() as tx:
+        tx.upsert(table, "a", "1")
+        tx.upsert(table, "b", "2")
+
+    assert client.get(table, "a") == "1"
+    assert client.get(table, "b") == "2"
+
+
+def test_abandoned_transaction_not_applied(server, unique_table):
+    """A transaction whose token is dropped without commit leaves no trace."""
+    from sdb_testkit import SdbClient
+
+    table = unique_table()
+    with SdbClient(server.target) as setup:
+        setup.create_table(table)
+
+    with SdbClient(server.target) as writer:
+        tx = writer.begin()
+        writer.upsert(table, "ghost", "value", tx=tx)
+        # never commit
+
+    with SdbClient(server.target) as reader:
+        assert reader.get(table, "ghost") is None
+
+
+@pytest.mark.slow
+def test_committed_transaction_survives_restart(server, unique_table):
+    from sdb_testkit import SdbClient
+
+    table = unique_table()
+    with SdbClient(server.target) as client:
+        client.create_table(table)
+        with client.transaction() as tx:
+            tx.upsert(table, "k", "committed")
+
+    server.restart()
+
+    with SdbClient(server.target) as client:
+        assert client.get(table, "k") == "committed"

--- a/tests/integration/tests/test_transactions.py
+++ b/tests/integration/tests/test_transactions.py
@@ -10,75 +10,75 @@ import pytest
 
 
 def test_read_your_own_writes(client, unique_table):
-    table = unique_table()
-    client.create_table(table)
+    accounts = unique_table("accounts")
+    client.create_table(accounts)
 
-    with client.transaction() as tx:
-        tx.upsert(table, "k", "inside")
+    with client.transaction() as transaction:
+        transaction.upsert(accounts, "alice", "100")
         # The writing transaction sees its own uncommitted write.
-        assert tx.lookup(table, "k") == "inside"
+        assert transaction.lookup(accounts, "alice") == "100"
 
 
 def test_uncommitted_write_isolated_from_other_reader(server, unique_table):
     """A separate connection must not observe an in-flight transaction's write."""
     from sdb_testkit import SdbClient
 
-    table = unique_table()
+    accounts = unique_table("accounts")
     with SdbClient(server.target) as writer, SdbClient(server.target) as reader:
-        writer.create_table(table)
+        writer.create_table(accounts)
 
-        tx = writer.begin()
-        writer.upsert(table, "k", "pending", tx=tx)
+        transaction = writer.begin()
+        writer.upsert(accounts, "alice", "100", tx=transaction)
 
         # Outside the transaction the key is not yet visible.
-        assert reader.get(table, "k") is None
+        assert reader.get(accounts, "alice") is None
 
-        writer.commit(tx)
+        writer.commit(transaction)
 
         # After commit the value becomes visible to the other reader.
-        assert reader.get(table, "k") == "pending"
+        assert reader.get(accounts, "alice") == "100"
 
 
 def test_committed_transaction_is_visible(client, unique_table):
-    table = unique_table()
-    client.create_table(table)
+    accounts = unique_table("accounts")
+    client.create_table(accounts)
 
-    with client.transaction() as tx:
-        tx.upsert(table, "a", "1")
-        tx.upsert(table, "b", "2")
+    with client.transaction() as transaction:
+        transaction.upsert(accounts, "alice", "100")
+        transaction.upsert(accounts, "bob", "250")
 
-    assert client.get(table, "a") == "1"
-    assert client.get(table, "b") == "2"
+    assert client.get(accounts, "alice") == "100"
+    assert client.get(accounts, "bob") == "250"
 
 
 def test_abandoned_transaction_not_applied(server, unique_table):
     """A transaction whose token is dropped without commit leaves no trace."""
     from sdb_testkit import SdbClient
 
-    table = unique_table()
+    accounts = unique_table("accounts")
     with SdbClient(server.target) as setup:
-        setup.create_table(table)
+        setup.create_table(accounts)
 
     with SdbClient(server.target) as writer:
-        tx = writer.begin()
-        writer.upsert(table, "ghost", "value", tx=tx)
+        transaction = writer.begin()
+        writer.upsert(accounts, "carol", "999", tx=transaction)
         # never commit
 
     with SdbClient(server.target) as reader:
-        assert reader.get(table, "ghost") is None
+        assert reader.get(accounts, "carol") is None
 
 
 @pytest.mark.slow
 def test_committed_transaction_survives_restart(server, unique_table):
     from sdb_testkit import SdbClient
 
-    table = unique_table()
+    accounts = unique_table("accounts")
     with SdbClient(server.target) as client:
-        client.create_table(table)
-        with client.transaction() as tx:
-            tx.upsert(table, "k", "committed")
+        client.create_table(accounts)
+        with client.transaction() as transaction:
+            transaction.upsert(accounts, "alice", "100")
 
     server.restart()
 
     with SdbClient(server.target) as client:
-        assert client.get(table, "k") == "committed"
+        assert client.get(accounts, "alice") == "100"


### PR DESCRIPTION
## What

Adds `tests/integration/` — a Python integration-test framework that starts real `structuredb-server` processes and drives them over gRPC, covering table operations, transaction isolation and replication. Registered with ctest as the `integration` test.

## Framework (`sdb_testkit/`)

- **`config.py`** — `ServerConfig` → renders `config.yaml` (short flush/compaction/wal intervals for fast tests).
- **`server.py`** — `ServerProcess`: spawn, ready-wait on the port, `restart()` (WAL recovery), graceful teardown, captures `server.log` and surfaces its tail on a failed start.
- **`client.py`** — `SdbClient` (gRPC wrapper) + `Transaction`; threads the opaque `tx` token through requests, plus a `with client.transaction()` helper.
- **`cluster.py`** — `ReplicationCluster`: leader + N followers wired to stream the leader's WAL, with async-aware wait helpers.
- **`proto_gen.py`** — compiles & imports Python stubs from `proto/*.proto` on demand (regenerated by mtime), so there's no second copy of the protos.
- **`ports.py`, `waiting.py`** — free-port allocation and `wait_until` polling.

## Fixtures (`conftest.py`)

`server`, `client`, `server_config`, `make_cluster(followers=N)`, `unique_table`, `workdir`.

## Scenarios

- `test_tables.py` — CRUD, sorted scan + bounds, durability across restart.
- `test_transactions.py` — read-your-writes, isolation of uncommitted writes from another connection, atomic commit, abandoned-tx leaves no trace, survival across restart.
- `test_replication.py` — write propagation to follower, read-only rejection (`FAILED_PRECONDITION`), update/delete replication, multi-follower convergence.

## ctest integration

- `tests/integration/CMakeLists.txt` registers the `integration` test (label `integration`, 600s timeout), passing `$<TARGET_FILE:structuredb-server>`.
- Root `CMakeLists.txt` gains `add_subdirectory(tests/integration)`.
- `run_tests.py` bootstraps a local venv + installs `requirements.txt` + generates stubs, so the only host requirement is Python 3 (nothing installed system-wide). Generated artifacts (`.venv/`, `.generated/`) are gitignored.

## Verification

```
cd build/Debug && ctest -R integration --output-on-failure
1/1 Test #2: integration ... Passed  15.94 sec
```

All 17 tests pass (tables, transactions, replication).

🤖 Generated with [Claude Code](https://claude.com/claude-code)